### PR TITLE
Add cell counter output

### DIFF
--- a/src/main/kotlin/simplecolocalization/commands/SimpleCellCounter.kt
+++ b/src/main/kotlin/simplecolocalization/commands/SimpleCellCounter.kt
@@ -17,6 +17,8 @@ import org.scijava.plugin.Plugin
 import org.scijava.ui.UIService
 import org.scijava.widget.NumberWidget
 import simplecolocalization.services.CellSegmentationService
+import simplecolocalization.services.counter.output.CSVCounterOutput
+import simplecolocalization.services.counter.output.ImageJTableCounterOutput
 
 /**
  * Segments and counts cells which are almost circular in shape which are likely
@@ -43,6 +45,37 @@ class SimpleCellCounter : Command {
      */
     @Parameter
     private lateinit var uiService: UIService
+
+    @Parameter(
+        label = "Output Parameters:",
+        visibility = ItemVisibility.MESSAGE,
+        required = false
+    )
+    private lateinit var outputParametersHeader: String
+
+    /**
+     * The user can optionally output the results to a file.
+     */
+    object OutputDestination {
+        const val DISPLAY = "Display in table"
+        const val CSV = "Save as CSV file"
+    }
+
+    @Parameter(
+        label = "Results Output:",
+        choices = [OutputDestination.DISPLAY, OutputDestination.CSV],
+        required = true,
+        persist = false,
+        style = "radioButtonVertical"
+    )
+    private var outputDestination = OutputDestination.DISPLAY
+
+    @Parameter(
+        label = "Output File (if saving):",
+        style = "save",
+        required = false
+    )
+    private var outputFile: File? = null
 
     @Parameter(
         label = "Preprocessing Parameters:",
@@ -108,6 +141,14 @@ class SimpleCellCounter : Command {
 
     /** Processes single image. */
     private fun process(image: ImagePlus) {
+        if (outputDestination != SimpleColocalization.OutputDestination.DISPLAY && outputFile == null) {
+            MessageDialog(
+                IJ.getInstance(),
+                "Error", "File to save to not specified."
+            )
+            return
+        }
+
         // We need to create a copy of the image since we want to show the results on the original image, but
         // preprocessing is done in-place which changes the image.
         val originalImage = image.duplicate()
@@ -120,7 +161,22 @@ class SimpleCellCounter : Command {
         val cells = cellSegmentationService.identifyCells(roiManager, image)
         cellSegmentationService.markCells(originalImage, cells)
 
-        // TODO(sonjoonho): Show total cell count here.
+        if (outputDestination == OutputDestination.DISPLAY) {
+            ImageJTableCounterOutput(cells.size, uiService).output()
+        } else if (outputDestination == OutputDestination.CSV) {
+            CSVCounterOutput(cells.size, outputFile!!).output()
+        }
+
+        // The colocalization results are clearly displayed if the output
+        // destination is set to DISPLAY, however, a visual confirmation
+        // is useful if the output is saved to file.
+        if (outputDestination != SimpleColocalization.OutputDestination.DISPLAY) {
+            MessageDialog(
+                IJ.getInstance(),
+                "Saved",
+                "The cell counting results have successfully been saved to the specified file."
+            )
+        }
 
         originalImage.show()
     }

--- a/src/main/kotlin/simplecolocalization/services/counter/output/CSVCounterOutput.kt
+++ b/src/main/kotlin/simplecolocalization/services/counter/output/CSVCounterOutput.kt
@@ -1,0 +1,16 @@
+package simplecolocalization.services.counter.output
+
+import de.siegmar.fastcsv.writer.CsvWriter
+import java.io.File
+import java.nio.charset.StandardCharsets
+import java.util.ArrayList
+
+class CSVCounterOutput(private val count: Int, private val file: File) : CounterOutput() {
+
+    override fun output() {
+        val csvWriter = CsvWriter()
+        val outputData = ArrayList<Array<String>>()
+        outputData.add(arrayOf(count.toString()))
+        csvWriter.write(file, StandardCharsets.UTF_8, outputData)
+    }
+}

--- a/src/main/kotlin/simplecolocalization/services/counter/output/CounterOutput.kt
+++ b/src/main/kotlin/simplecolocalization/services/counter/output/CounterOutput.kt
@@ -1,0 +1,9 @@
+package simplecolocalization.services.counter.output
+
+/**
+ * Outputs the result of cell counting.
+ */
+abstract class CounterOutput {
+
+    abstract fun output()
+}

--- a/src/main/kotlin/simplecolocalization/services/counter/output/ImageJTableCounterOutput.kt
+++ b/src/main/kotlin/simplecolocalization/services/counter/output/ImageJTableCounterOutput.kt
@@ -1,0 +1,17 @@
+package simplecolocalization.services.counter.output
+
+import org.scijava.table.DefaultGenericTable
+import org.scijava.table.IntColumn
+import org.scijava.ui.UIService
+
+class ImageJTableCounterOutput(private val count: Int, private val uiService: UIService) : CounterOutput() {
+
+    override fun output() {
+        val table = DefaultGenericTable()
+        val countColumn = IntColumn()
+        countColumn.add(count)
+        table.add(countColumn)
+        table.setColumnHeader(0, "Count")
+        uiService.show(table)
+    }
+}


### PR DESCRIPTION
Adds output of cell counter to table (CSV) or results table.

The output will only be a single cell due to the convention that ImageJ plugins work on one image at a time. Batching steps will need to take care of reconciling separate CSVs into a single one.

![image](https://user-images.githubusercontent.com/1910781/69238510-1f818700-0b90-11ea-8d4c-4bcde8531c2e.png)
