### PR TITLE
Tune colocalization parameters to accept more transduction

### DIFF
--- a/src/main/kotlin/simplecolocalization/commands/SimpleColocalization.kt
+++ b/src/main/kotlin/simplecolocalization/commands/SimpleColocalization.kt
@@ -39,7 +39,7 @@ import simplecolocalization.services.colocalizer.showCells
 @Plugin(type = Command::class, menuPath = "Plugins > Simple Cells > Simple Colocalization")
 class SimpleColocalization : Command {
 
-    private val intensityPercentageThreshold: Float = 40f
+    private val intensityPercentageThreshold: Float = 90f
 
     @Parameter
     private lateinit var logService: LogService
@@ -203,7 +203,7 @@ class SimpleColocalization : Command {
             largestCellDiameter.toInt(),
             targetChannel.width,
             targetChannel.height,
-            PixelCellComparator()
+            PixelCellComparator(threshold = 0.01f)
         ).analyseTransduction(targetCells, transducedCells)
 
         val targetCellTransductionAnalysis = cellColocalizationService.analyseCellIntensity(


### PR DESCRIPTION
Currently, intensity filtering is removing a number of cells from the colocalization result.

For example, with of `MAX_19.01.15 Exosomal mouse retina GFP 488 Brn3A 555 TUJ1 647 40X 1.5.lif - 29 perip 1`, the results is as follows:
![image](https://user-images.githubusercontent.com/1910781/69904367-c8549100-139d-11ea-8130-8a47e7f4f07b.png)

---

For comparison, we can deduce from the below Simple_CellCounter_ output that many more cells should be circled:

**(Red channel only)**
![image](https://user-images.githubusercontent.com/1910781/69904328-57ad7480-139d-11ea-9bb5-0a5ac41563ff.png)

**(Both red and green channels)**
![image](https://user-images.githubusercontent.com/1910781/69904330-5a0fce80-139d-11ea-8c6d-8cd3df993e3c.png)

---

By increasing the amount cell overlap is allowed for transduction to be considered and reducing the relative intensity parameter, we allow more cells, producing the following result:

![image](https://user-images.githubusercontent.com/1910781/69904388-ffc33d80-139d-11ea-9dfa-b2e26aa59a74.png)

