### PR TITLE
Clean up simple batching parameters

### DIFF
--- a/src/main/kotlin/simplecolocalization/commands/SimpleBatch.kt
+++ b/src/main/kotlin/simplecolocalization/commands/SimpleBatch.kt
@@ -4,6 +4,7 @@ import ij.IJ
 import ij.gui.GenericDialog
 import ij.gui.MessageDialog
 import java.io.File
+import java.io.IOException
 import net.imagej.ImageJ
 import org.scijava.Context
 import org.scijava.command.Command
@@ -15,7 +16,6 @@ import org.scijava.widget.NumberWidget
 import simplecolocalization.preprocessing.PreprocessingParameters
 import simplecolocalization.services.CellSegmentationService
 import simplecolocalization.services.counter.output.CSVCounterOutput
-import java.io.IOException
 
 @Plugin(type = Command::class, menuPath = "Plugins > Simple Cells > Simple Batch")
 class SimpleBatch : Command {


### PR DESCRIPTION
- Adds dialog boxes as script parameters for input directory and output file
- Temporarily remove results table choice parameter
- Express choice of plugins with radio buttons instead of dropdown to not hide important choices
- Adds functionality to append ".csv" automatically if extension missing from output file
- Expresses GenericDialog code for dialog boxes more idiomatically
- Checks for IOException when saving output
- Fixes issue where PluginOutput placed outside of class scope caused IntelliJ to not recognise SimpleBatch.kt as a class file