### PR TITLE
Move the post-blur thresholding inside the if-block for the blur

### DIFF
--- a/src/main/kotlin/simplecolocalization/services/CellSegmentationService.kt
+++ b/src/main/kotlin/simplecolocalization/services/CellSegmentationService.kt
@@ -94,11 +94,11 @@ class CellSegmentationService : AbstractService(), ImageJService {
         if (params.shouldGaussianBlur) {
             // Apply Gaussian Blur to group larger speckles.
             image.channelProcessor.blurGaussian(params.gaussianBlurSigma)
-        }
 
-        // Threshold image again to remove blur.
-        image.processor.setAutoThreshold(AutoThresholder.Method.Otsu, true)
-        image.processor.autoThreshold()
+            // Threshold image again to remove blur.
+            image.processor.setAutoThreshold(AutoThresholder.Method.Otsu, true)
+            image.processor.autoThreshold()
+        }
     }
 
     /**


### PR DESCRIPTION
Remove redundant use of thresholding by moving it inside the if-block for the gaussian blur. The reason for this thresholding is simply to binarize the image after the blur is applied, therefore it should only occur if the gaussian blur happens. 