### PR TITLE
Fix selection of target cell in colocalisation

### DIFF
--- a/src/main/kotlin/simplecolocalization/services/colocalizer/BucketedNaiveColocalizer.kt
+++ b/src/main/kotlin/simplecolocalization/services/colocalizer/BucketedNaiveColocalizer.kt
@@ -52,9 +52,14 @@ class BucketedNaiveColocalizer(var bucketLength: Int, val imageWidth: Int, val i
         }
 
         // Reconcile the transduction results.
-        val overlapping = colocalizationAnalyses.flatMap { analysis -> analysis.overlapping }.toHashSet()
-        val disjoint = colocalizationAnalyses.flatMap { analysis -> analysis.disjoint }.toHashSet() subtract overlapping
-        return ColocalizationAnalysis(overlapping.toList(), disjoint.toList())
+        val overlappingBase = colocalizationAnalyses.flatMap { analysis -> analysis.overlappingBase }.toHashSet()
+        val overlappingOverlaid = colocalizationAnalyses.flatMap { analysis -> analysis.overlappingOverlaid }.toHashSet()
+        val disjoint = colocalizationAnalyses.flatMap { analysis -> analysis.disjoint }.toHashSet() subtract overlappingOverlaid
+        return ColocalizationAnalysis(
+            overlappingBase = overlappingBase.toList(),
+            overlappingOverlaid = overlappingOverlaid.toList(),
+            disjoint = disjoint.toList()
+        )
     }
 
     private fun surroundingBucketsForBucket(bucket: Bucket): Set<Bucket> {

--- a/src/main/kotlin/simplecolocalization/services/colocalizer/Colocalizer.kt
+++ b/src/main/kotlin/simplecolocalization/services/colocalizer/Colocalizer.kt
@@ -6,7 +6,7 @@ import simplecolocalization.services.cellcomparator.CellComparator
  * Colocalization analysis contains the list of overlaid cells which overlap base cells and a list of overlaid
  * cells which do not overlap base cells.
  */
-data class ColocalizationAnalysis(val overlapping: List<PositionedCell>, val disjoint: List<PositionedCell>)
+data class ColocalizationAnalysis(val overlappingBase: List<PositionedCell>, val overlappingOverlaid: List<PositionedCell>, val disjoint: List<PositionedCell>)
 
 /**
  * Analyses the colocalization between cells which are intended to be the

--- a/src/main/kotlin/simplecolocalization/services/colocalizer/NaiveColocalizer.kt
+++ b/src/main/kotlin/simplecolocalization/services/colocalizer/NaiveColocalizer.kt
@@ -15,10 +15,17 @@ open class NaiveColocalizer(cellComparator: CellComparator) :
         baseCells: List<PositionedCell>,
         overlaidCells: List<PositionedCell>
     ): ColocalizationAnalysis {
-        val overlap = overlaidCells.filter { overlaidCell ->
-            baseCells.any { isOverlapping(overlaidCell, it) }
-        }
+        val overlaidBaseOverlap = overlaidCells.map { overlaidCell ->
+            overlaidCell to baseCells.filter { isOverlapping(overlaidCell, it) }
+        }.toMap()
 
-        return ColocalizationAnalysis(overlap, overlaidCells.minus(overlap))
+        val overlappingBaseCells = overlaidBaseOverlap.values.flatten().toSet()
+        val overlappingOverlaidCells = overlaidBaseOverlap.filter { it.value.isNotEmpty() }.keys
+
+        return ColocalizationAnalysis(
+            overlappingBase = overlappingBaseCells.toList(),
+            overlappingOverlaid = overlappingOverlaidCells.toList(),
+            disjoint = overlaidCells.minus(overlappingOverlaidCells)
+        )
     }
 }

--- a/src/main/kotlin/simplecolocalization/services/colocalizer/output/CSVColocalizationOutput.kt
+++ b/src/main/kotlin/simplecolocalization/services/colocalizer/output/CSVColocalizationOutput.kt
@@ -29,7 +29,7 @@ class CSVColocalizationOutput(
         outputData.add(arrayOf("Quantification of each transduced cells overlapping target cells below --", "", "", ""))
 
         // Per-cell analysis
-        result.overlappingTransducedCellAnalyses.forEach { outputData.add(arrayOf("", "1", it.area.toString(), it.median.toString(), it.mean.toString())) }
+        result.overlappingTransducedIntensityAnalysis.forEach { outputData.add(arrayOf("", "1", it.area.toString(), it.median.toString(), it.mean.toString())) }
 
         csvWriter.write(file, StandardCharsets.UTF_8, outputData)
     }

--- a/src/main/kotlin/simplecolocalization/services/colocalizer/output/ImageJTableColocalizationOutput.kt
+++ b/src/main/kotlin/simplecolocalization/services/colocalizer/output/ImageJTableColocalizationOutput.kt
@@ -52,7 +52,7 @@ class ImageJTableColocalizationOutput(
         meanColumn.add(0)
 
         // Construct column values using the channel analysis values.
-        result.overlappingTransducedCellAnalyses.forEach {
+        result.overlappingTransducedIntensityAnalysis.forEach {
             labelColumn.add("")
             countColumn.add(1)
             areaColumn.add(it.area)

--- a/src/test/kotlin/simplecolocalization/services/colocalizer/BucketedNaiveColocalizerTest.kt
+++ b/src/test/kotlin/simplecolocalization/services/colocalizer/BucketedNaiveColocalizerTest.kt
@@ -14,7 +14,11 @@ class BucketedNaiveColocalizerTest : FreeSpec() {
                     0f,
                     listOf(squareCell(0, 3, 0, 3), squareCell(6, 7, 6, 7)),
                     listOf(squareCell(2, 5, 2, 5), squareCell(0, 1, 6, 7)),
-                    ColocalizationAnalysis(listOf(squareCell(2, 5, 2, 5)), listOf(squareCell(0, 1, 6, 7)))
+                    ColocalizationAnalysis(
+                        listOf(squareCell(0, 3, 0, 3)),
+                        listOf(squareCell(2, 5, 2, 5)),
+                        listOf(squareCell(0, 1, 6, 7))
+                    )
                 )
             ).map { (description: String, threshold: Float, target: List<PositionedCell>, transduced: List<PositionedCell>, expected: ColocalizationAnalysis) ->
                 description {

--- a/src/test/kotlin/simplecolocalization/services/colocalizer/NaiveColocalizerTest.kt
+++ b/src/test/kotlin/simplecolocalization/services/colocalizer/NaiveColocalizerTest.kt
@@ -13,28 +13,44 @@ class NaiveColocalizerTest : FreeSpec({
                 0f,
                 listOf(PositionedCell(hashSetOf(Pair(0, 0), Pair(0, 1), Pair(1, 0), Pair(1, 1)))),
                 listOf(PositionedCell(hashSetOf(Pair(0, 0)))),
-                ColocalizationAnalysis(listOf(PositionedCell(hashSetOf(Pair(0, 0)))), listOf())
+                ColocalizationAnalysis(
+                    listOf(PositionedCell(hashSetOf(Pair(0, 0), Pair(0, 1), Pair(1, 0), Pair(1, 1)))),
+                    listOf(PositionedCell(hashSetOf(Pair(0, 0)))),
+                    listOf()
+                )
             ),
             row(
                 "one threshold matches no cells",
                 1f,
                 listOf(PositionedCell(hashSetOf(Pair(0, 0), Pair(0, 1), Pair(1, 0), Pair(1, 1)))),
                 listOf(PositionedCell(hashSetOf(Pair(0, 0)))),
-                ColocalizationAnalysis(listOf(), listOf(PositionedCell(hashSetOf(Pair(0, 0)))))
+                ColocalizationAnalysis(
+                    listOf(),
+                    listOf(),
+                    listOf(PositionedCell(hashSetOf(Pair(0, 0))))
+                )
             ),
             row(
                 "transduced cell overlaps multiple target cells",
                 0.2f,
                 listOf(PositionedCell(hashSetOf(Pair(0, 0))), PositionedCell(hashSetOf(Pair(0, 1))), PositionedCell(hashSetOf(Pair(1, 0))), PositionedCell(hashSetOf(Pair(1, 1)))),
                 listOf(PositionedCell(hashSetOf(Pair(0, 0), Pair(0, 1), Pair(1, 0), Pair(1, 1)))),
-                ColocalizationAnalysis(listOf(PositionedCell(hashSetOf(Pair(0, 0), Pair(0, 1), Pair(1, 0), Pair(1, 1)))), listOf())
+                ColocalizationAnalysis(
+                    listOf(PositionedCell(hashSetOf(Pair(0, 0))), PositionedCell(hashSetOf(Pair(0, 1))), PositionedCell(hashSetOf(Pair(1, 0))), PositionedCell(hashSetOf(Pair(1, 1)))),
+                    listOf(PositionedCell(hashSetOf(Pair(0, 0), Pair(0, 1), Pair(1, 0), Pair(1, 1)))),
+                    listOf()
+                )
             ),
             row(
                 "transduced cell does not overlap any target cells",
                 0f,
                 listOf(PositionedCell(hashSetOf(Pair(0, 0))), PositionedCell(hashSetOf(Pair(0, 1))), PositionedCell(hashSetOf(Pair(1, 0))), PositionedCell(hashSetOf(Pair(1, 1)))),
                 listOf(PositionedCell(hashSetOf(Pair(2, 2)))),
-                ColocalizationAnalysis(listOf(), listOf(PositionedCell(hashSetOf(Pair(2, 2)))))
+                ColocalizationAnalysis(
+                    listOf(),
+                    listOf(),
+                    listOf(PositionedCell(hashSetOf(Pair(2, 2))))
+                )
             )
         ).map { (description: String, threshold: Float, target: List<PositionedCell>, transduced: List<PositionedCell>, expected: ColocalizationAnalysis) ->
             description {


### PR DESCRIPTION
Achieved by creating a distinction between overlapping cells which were target ROIs and transduced ROIs.

![image](https://user-images.githubusercontent.com/1910781/71648334-daa64f80-2cfa-11ea-9bd9-9a4f701b281b.png)

![image](https://user-images.githubusercontent.com/1910781/71648335-de39d680-2cfa-11ea-90c7-7cc57d19b89b.png)

![image](https://user-images.githubusercontent.com/1910781/71648336-e09c3080-2cfa-11ea-9bea-75eb63cff3c6.png)

+R: @sonjoonho 
+CC: @Tiger-Cross 