### PR TITLE
Implement SubsetPixelCellComparator

### DIFF
--- a/src/main/kotlin/simplecolocalization/commands/SimpleColocalization.kt
+++ b/src/main/kotlin/simplecolocalization/commands/SimpleColocalization.kt
@@ -27,6 +27,7 @@ import simplecolocalization.preprocessing.PreprocessingParameters
 import simplecolocalization.services.CellColocalizationService
 import simplecolocalization.services.CellSegmentationService
 import simplecolocalization.services.cellcomparator.PixelCellComparator
+import simplecolocalization.services.cellcomparator.SubsetPixelCellComparator
 import simplecolocalization.services.colocalizer.BucketedNaiveColocalizer
 import simplecolocalization.services.colocalizer.ColocalizationAnalysis
 import simplecolocalization.services.colocalizer.PositionedCell
@@ -271,7 +272,7 @@ class SimpleColocalization : Command {
             largestCellDiameter.toInt(),
             targetChannel.width,
             targetChannel.height,
-            PixelCellComparator(threshold = 0.01f)
+            SubsetPixelCellComparator(threshold = 0.5f)
         ).analyseColocalization(targetCells, transducedCells)
 
         val transductionIntensityAnalysis = cellColocalizationService.analyseCellIntensity(

--- a/src/main/kotlin/simplecolocalization/services/cellcomparator/SubsetPixelCellComparator.kt
+++ b/src/main/kotlin/simplecolocalization/services/cellcomparator/SubsetPixelCellComparator.kt
@@ -1,0 +1,26 @@
+package simplecolocalization.services.cellcomparator
+
+import simplecolocalization.services.colocalizer.PositionedCell
+
+/**
+ * Determines whether two cells overlap using the percentage overlap of pixels in the
+ * case where one cell is smaller than the other.
+ *
+ * If the proportion is larger than the threshold then cells are considered overlapping.
+ */
+class SubsetPixelCellComparator(private val threshold: Float = 0.5f) : CellComparator {
+
+    init {
+        require(threshold in 0.0..1.0) { "Overlap threshold must be between 0 and 1" }
+    }
+
+    /**
+     * @property firstCell The smaller cell.
+     * @property secondCell The larger cell.
+     */
+    override fun cellsOverlap(firstCell: PositionedCell, secondCell: PositionedCell): Boolean {
+        val overlap = (firstCell.points intersect secondCell.points).size.toFloat()
+        val total = secondCell.points.size.toFloat()
+        return (overlap / total) > threshold
+    }
+}


### PR DESCRIPTION
Adds a pixel cell comparator which accounts for one channel's cells being smaller than the other.

After:

![image](https://user-images.githubusercontent.com/1910781/71668629-98642900-2d61-11ea-96aa-8726be6a411f.png)

Before:

![image](https://user-images.githubusercontent.com/1910781/71668641-a154fa80-2d61-11ea-95b3-dbe3894a4983.png)

Notice the false positive removal in the bottom-left corner.

Threshold value discussion can be found here: https://icdreamteam2k19.slack.com/archives/CPKFV9PU7/p1577970492022800

+R: @sonjoonho 
+CC: @willburr 