### PR TITLE
Add smallest cell diameter parameter and use diameters in ParticleAnalyzer

### DIFF
--- a/src/main/kotlin/simplecolocalization/commands/SimpleCellCounter.kt
+++ b/src/main/kotlin/simplecolocalization/commands/SimpleCellCounter.kt
@@ -60,6 +60,20 @@ class SimpleCellCounter : Command {
     private lateinit var processingParametersHeader: String
 
     /**
+     * Used during the cell identification stage to filter out cells that are too small
+     */
+    @Parameter(
+        label = "Smallest Cell Diameter (px)",
+        description = "Value we use as minimum diameter when identifying cells",
+        min = "0.0",
+        stepSize = "1",
+        style = NumberWidget.SPINNER_STYLE,
+        required = true,
+        persist = false
+    )
+    private var smallestCellDiameter = 0.0
+
+    /**
      * Used during the cell segmentation stage to perform local thresholding or
      * background subtraction.
      */
@@ -67,7 +81,7 @@ class SimpleCellCounter : Command {
         label = "Largest Cell Diameter (px)",
         description = "Value we use to apply the rolling ball algorithm to subtract " +
             "the background when thresholding",
-            min = "1",
+        min = "1",
         stepSize = "1",
         style = NumberWidget.SPINNER_STYLE,
         required = true,
@@ -126,6 +140,15 @@ class SimpleCellCounter : Command {
         val image = WindowManager.getCurrentImage()
         if (image == null) {
             MessageDialog(IJ.getInstance(), "Error", "There is no file open")
+            return
+        }
+
+        if (smallestCellDiameter > largestCellDiameter) {
+            MessageDialog(
+                IJ.getInstance(),
+                "Error",
+                "Smallest cell diameter must be smaller than the largest cell diameter"
+            )
             return
         }
 
@@ -192,7 +215,7 @@ class SimpleCellCounter : Command {
     /** Processes single image. */
     fun process(image: ImagePlus): CounterResult {
 
-        val cells = cellSegmentationService.extractCells(image, largestCellDiameter, gaussianBlurSigma)
+        val cells = cellSegmentationService.extractCells(image, smallestCellDiameter, largestCellDiameter, gaussianBlurSigma)
         return CounterResult(cells.size, cells)
     }
 

--- a/src/main/kotlin/simplecolocalization/commands/SimpleColocalization.kt
+++ b/src/main/kotlin/simplecolocalization/commands/SimpleColocalization.kt
@@ -121,6 +121,20 @@ class SimpleColocalization : Command {
     private lateinit var preprocessingParamsHeader: String
 
     /**
+     * Used during the cell identification stage to filter out cells that are too small
+     */
+    @Parameter(
+        label = "Smallest Cell Diameter for Morphology Channel 1 (px)",
+        description = "Value we use as minimum diameter when identifying cells",
+        min = "0.0",
+        stepSize = "1",
+        style = NumberWidget.SPINNER_STYLE,
+        required = true,
+        persist = false
+    )
+    private var smallestCellDiameter = 0.0
+
+    /**
      * Used during the cell segmentation stage to reduce overlapping cells
      * being grouped into a single cell and perform local thresholding or
      * background subtraction.
@@ -134,6 +148,20 @@ class SimpleColocalization : Command {
         persist = false
     )
     private var largestCellDiameter = 30.0
+
+    /**
+     * Used during the cell identification stage to filter out cells that are too small
+     */
+    @Parameter(
+        label = "Smallest Cell Diameter for Morphology Channel 2 (px) (only if enabled)",
+        description = "Value we use as minimum diameter when identifying cells",
+        min = "0.0",
+        stepSize = "1",
+        style = NumberWidget.SPINNER_STYLE,
+        required = true,
+        persist = false
+    )
+    private var smallestAllCellsDiameter = 0.0
 
     @Parameter(
         label = "Largest Cell Diameter for Morphology Channel 2 (px) (only if enabled)",
@@ -295,14 +323,15 @@ class SimpleColocalization : Command {
     fun analyseTransduction(targetChannel: ImagePlus, transducedChannel: ImagePlus, allCellsChannel: ImagePlus? = null): TransductionResult {
         logService.info("Starting extraction")
         // TODO(#77)
-        val targetCells = cellSegmentationService.extractCells(targetChannel, largestCellDiameter, gaussianBlurSigma = 3.0)
+        val targetCells = cellSegmentationService.extractCells(targetChannel, smallestCellDiameter, largestCellDiameter, gaussianBlurSigma = 3.0)
         val transducedCells = filterCellsByIntensity(
-            cellSegmentationService.extractCells(transducedChannel, largestCellDiameter, gaussianBlurSigma = 3.0),
+            cellSegmentationService.extractCells(transducedChannel, smallestCellDiameter, largestCellDiameter, gaussianBlurSigma = 3.0),
             transducedChannel
         )
         // TODO(#105) ^^
         val allCells = if (allCellsChannel != null) cellSegmentationService.extractCells(
             allCellsChannel,
+            smallestCellDiameter,
             largestAllCellsDiameter,
             gaussianBlurSigma = 3.0
         ) else null


### PR DESCRIPTION
Closes #101 

- Add Smallest Cell Diameter parameter to the SimpleCellCounter dialog 
- Use Smallest Cell Diameter to calculate minimum area given in pixels^2 to ParticleAnalyzer
- Use Largest Cell Diameter to calculate maximum area in pixels^2 given to ParticleAnalyzer
