### PR TITLE
Convert from array to list of CellAnalysis

### DIFF
--- a/src/main/kotlin/simplergc/commands/RGCTransduction.kt
+++ b/src/main/kotlin/simplergc/commands/RGCTransduction.kt
@@ -220,7 +220,7 @@ class RGCTransduction : Command, Previewable {
      */
     data class TransductionResult(
         val targetCellCount: Int, // Number of red cells
-        val overlappingTransducedIntensityAnalysis: Array<CellColocalizationService.CellAnalysis>,
+        val overlappingTransducedIntensityAnalysis: List<CellColocalizationService.CellAnalysis>,
         val overlappingTwoChannelCells: List<PositionedCell>
     ) {
         data class Summary(
@@ -395,7 +395,7 @@ class RGCTransduction : Command, Previewable {
 
         val transductionIntensityAnalysis = cellColocalizationService.analyseCellIntensity(
             transducedChannel,
-            targetTransducedAnalysis.overlappingOverlaid.map { it.toRoi() }.toTypedArray()
+            targetTransducedAnalysis.overlappingOverlaid.map { it.toRoi() }
         )
 
         // We return the overlapping target channel instead of transduced channel as we want to mark the target layer,

--- a/src/main/kotlin/simplergc/services/CellColocalizationService.kt
+++ b/src/main/kotlin/simplergc/services/CellColocalizationService.kt
@@ -24,7 +24,7 @@ class CellColocalizationService : AbstractService(), ImageJService {
      *
      *  Takes in [image], a greyscale image (representing the target channel).
      */
-    fun analyseCellIntensity(image: ImagePlus, cells: Array<Roi>): Array<CellAnalysis> {
+    fun analyseCellIntensity(image: ImagePlus, cells: List<Roi>): List<CellAnalysis> {
         return cells.map { cell ->
             var area = 0
             var sum = 0
@@ -39,7 +39,7 @@ class CellColocalizationService : AbstractService(), ImageJService {
             val min = sortedPixelintensities.first()
             val max = sortedPixelintensities.last()
             CellAnalysis(area, sum / area, median, min, max, rawIntDen = sum)
-        }.toTypedArray()
+        }
     }
 
     /** Counts the number of analysed cells that exceed the channel intensity threshold. */


### PR DESCRIPTION
Just a nit that has been bugging me. You should not use an array as a constructor member of a data class. This is because the kotlin compiler generates hashcode() and equals() implementations for data classes and since array equality isn't structural, you either have to override equals and hashcode for the array or.... just use a list lol.