### PR TITLE
Fix transducedChannel index for ImageJ output

### DIFF
--- a/src/main/kotlin/simplergc/services/colocalizer/output/ImageJTableColocalizationOutput.kt
+++ b/src/main/kotlin/simplergc/services/colocalizer/output/ImageJTableColocalizationOutput.kt
@@ -72,7 +72,7 @@ class ImageJTableColocalizationOutput(
         table.addRow(
             Row(
                 label = "Mean intensity of colocalized cells",
-                count = result.channelResults[transducedChannel].cellAnalyses.sumBy { it.mean } / result.channelResults[transducedChannel].cellAnalyses.size))
+                count = result.channelResults[transducedChannel - 1].cellAnalyses.sumBy { it.mean } / result.channelResults[transducedChannel - 1].cellAnalyses.size))
     }
 
     override fun writeAnalysis() {


### PR DESCRIPTION
Use `transducedChannel - 1` for the mean intensity of colocalized cells in ImageJ. 