### PR TITLE
Remove output file from Parameters object and pass it separately

### DIFF
--- a/src/main/kotlin/simplergc/commands/RGCCounter.kt
+++ b/src/main/kotlin/simplergc/commands/RGCCounter.kt
@@ -219,7 +219,6 @@ class RGCCounter : Command, Previewable {
 
     private fun writeOutput(numCells: Int, file: String, cellDiameterRange: CellDiameterRange) {
         val counterParameters = Parameters.Counter(
-            outputFile!!,
             targetChannel,
             cellDiameterRange,
             localThresholdRadius,
@@ -227,8 +226,8 @@ class RGCCounter : Command, Previewable {
         )
         val output = when (outputFormat) {
             OutputFormat.DISPLAY -> ImageJTableCounterOutput(uiService)
-            OutputFormat.XLSX -> XlsxCounterOutput(counterParameters)
-            OutputFormat.CSV -> CsvCounterOutput(counterParameters)
+            OutputFormat.XLSX -> XlsxCounterOutput(outputFile!!, counterParameters)
+            OutputFormat.CSV -> CsvCounterOutput(outputFile!!, counterParameters)
             else -> throw IllegalArgumentException("Invalid output type provided")
         }
 

--- a/src/main/kotlin/simplergc/commands/RGCTransduction.kt
+++ b/src/main/kotlin/simplergc/commands/RGCTransduction.kt
@@ -279,7 +279,6 @@ class RGCTransduction : Command, Previewable {
 
     private fun writeOutput(inputFileName: String, result: TransductionResult) {
         val transductionParameters = Parameters.Transduction(
-            outputFile!!,
             shouldRemoveAxonsFromTargetChannel,
             transducedChannel,
             shouldRemoveAxonsFromTransductionChannel,
@@ -290,8 +289,8 @@ class RGCTransduction : Command, Previewable {
         )
         val output = when (outputFormat) {
             OutputFormat.DISPLAY -> ImageJTableColocalizationOutput(transductionParameters, result, uiService)
-            OutputFormat.XLSX -> XlsxColocalizationOutput(transductionParameters)
-            OutputFormat.CSV -> CsvColocalizationOutput(transductionParameters)
+            OutputFormat.XLSX -> XlsxColocalizationOutput(outputFile!!, transductionParameters)
+            OutputFormat.CSV -> CsvColocalizationOutput(outputFile!!, transductionParameters)
             else -> throw IllegalArgumentException("Invalid output type provided")
         }
 

--- a/src/main/kotlin/simplergc/commands/batch/BatchableCellCounter.kt
+++ b/src/main/kotlin/simplergc/commands/batch/BatchableCellCounter.kt
@@ -35,7 +35,6 @@ class BatchableCellCounter(
         val imageAndCount = inputImages.zip(numCellsList)
 
         val counterParameters = Parameters.Counter(
-            outputFile,
             targetChannel,
             cellDiameterRange,
             localThresholdRadius,
@@ -43,8 +42,8 @@ class BatchableCellCounter(
         )
 
         val output = when (outputFormat) {
-            OutputFormat.CSV -> CsvCounterOutput(counterParameters)
-            OutputFormat.XLSX -> XlsxCounterOutput(counterParameters)
+            OutputFormat.CSV -> CsvCounterOutput(outputFile, counterParameters)
+            OutputFormat.XLSX -> XlsxCounterOutput(outputFile, counterParameters)
             else -> throw IllegalArgumentException("Invalid output type provided")
         }
 

--- a/src/main/kotlin/simplergc/commands/batch/BatchableColocalizer.kt
+++ b/src/main/kotlin/simplergc/commands/batch/BatchableColocalizer.kt
@@ -49,7 +49,6 @@ class BatchableColocalizer(
         }
 
         val transductionParameters = Parameters.Transduction(
-            outputFile,
             shouldRemoveAxonsFromTargetChannel,
             transducedChannel,
             shouldRemoveAxonsFromTransductionChannel,
@@ -59,17 +58,18 @@ class BatchableColocalizer(
             targetChannel
         )
 
-        writeOutput(fileNameAndAnalysis, transductionParameters, outputFormat)
+        writeOutput(outputFile, fileNameAndAnalysis, transductionParameters, outputFormat)
     }
 
     private fun writeOutput(
+        outputFile: File,
         fileNameAndAnalysis: List<Pair<String, TransductionResult>>,
         transductionParameters: Parameters.Transduction,
         outputFormat: String
     ) {
         val output = when (outputFormat) {
-            OutputFormat.XLSX -> BatchXlsxColocalizationOutput(transductionParameters)
-            OutputFormat.CSV -> BatchCsvColocalizationOutput(transductionParameters)
+            OutputFormat.XLSX -> BatchXlsxColocalizationOutput(outputFile, transductionParameters)
+            OutputFormat.CSV -> BatchCsvColocalizationOutput(outputFile, transductionParameters)
             else -> throw IllegalArgumentException("Invalid output type provided: $outputFormat")
         }
 

--- a/src/main/kotlin/simplergc/services/Output.kt
+++ b/src/main/kotlin/simplergc/services/Output.kt
@@ -1,7 +1,5 @@
 package simplergc.services
 
-import java.io.File
-
 /**
  * Output defines an object that can process and output a Table.
  */
@@ -22,7 +20,6 @@ interface Output {
  */
 sealed class Parameters {
     data class Counter(
-        val outputFile: File,
         val targetChannel: Int,
         val cellDiameterRange: CellDiameterRange,
         val localThresholdRadius: Int,
@@ -30,7 +27,6 @@ sealed class Parameters {
     ) : Parameters()
 
     data class Transduction(
-        val outputFile: File,
         val shouldRemoveAxonsFromTargetChannel: Boolean,
         val transducedChannel: Int,
         val shouldRemoveAxonsFromTransductionChannel: Boolean,

--- a/src/main/kotlin/simplergc/services/batch/output/BatchCsvColocalizationOutput.kt
+++ b/src/main/kotlin/simplergc/services/batch/output/BatchCsvColocalizationOutput.kt
@@ -1,5 +1,6 @@
 package simplergc.services.batch.output
 
+import java.io.File
 import simplergc.services.Aggregate
 import simplergc.services.AggregateRow
 import simplergc.services.CsvTableWriter
@@ -18,10 +19,10 @@ import simplergc.services.colocalizer.output.CsvColocalizationOutput
  *
  * For some operations it delegates to colocalizationOutput.
  */
-class BatchCsvColocalizationOutput(transductionParameters: Parameters.Transduction) :
+class BatchCsvColocalizationOutput(outputFile: File, transductionParameters: Parameters.Transduction) :
     BatchColocalizationOutput() {
 
-    override val colocalizationOutput = CsvColocalizationOutput(transductionParameters)
+    override val colocalizationOutput = CsvColocalizationOutput(outputFile, transductionParameters)
 
     override val tableWriter = CsvTableWriter()
 

--- a/src/main/kotlin/simplergc/services/batch/output/BatchXlsxColocalizationOutput.kt
+++ b/src/main/kotlin/simplergc/services/batch/output/BatchXlsxColocalizationOutput.kt
@@ -1,5 +1,6 @@
 package simplergc.services.batch.output
 
+import java.io.File
 import org.apache.poi.xssf.usermodel.XSSFWorkbook
 import simplergc.services.Aggregate
 import simplergc.services.AggregateRow
@@ -19,12 +20,12 @@ import simplergc.services.colocalizer.output.XlsxColocalizationOutput
  *     - Parameters
  * For some operations it delegates to colocalizationOutput.
  */
-class BatchXlsxColocalizationOutput(transductionParameters: Parameters.Transduction) :
+class BatchXlsxColocalizationOutput(outputFile: File, transductionParameters: Parameters.Transduction) :
     BatchColocalizationOutput() {
 
     private val workbook = XSSFWorkbook()
 
-    override val colocalizationOutput = XlsxColocalizationOutput(transductionParameters, workbook)
+    override val colocalizationOutput = XlsxColocalizationOutput(outputFile, transductionParameters, workbook)
 
     override val tableWriter: TableWriter = XlsxTableWriter(workbook)
 

--- a/src/main/kotlin/simplergc/services/colocalizer/output/CsvColocalizationOutput.kt
+++ b/src/main/kotlin/simplergc/services/colocalizer/output/CsvColocalizationOutput.kt
@@ -16,10 +16,13 @@ import simplergc.services.Parameters
  *     - Analysis - [Channel].csv for each channel in image
  *     - Parameters.csv
  */
-class CsvColocalizationOutput(transductionParameters: Parameters.Transduction) :
+class CsvColocalizationOutput(
+    private val outputFile: File,
+    transductionParameters: Parameters.Transduction
+) :
     ColocalizationOutput(transductionParameters) {
 
-    val outputPath: String = "${transductionParameters.outputFile.path}${File.separator}"
+    val outputPath: String = "${outputFile.path}${File.separator}"
     override val tableWriter = CsvTableWriter()
 
     override fun output() {
@@ -31,9 +34,9 @@ class CsvColocalizationOutput(transductionParameters: Parameters.Transduction) :
     }
 
     fun createOutputFolder() {
-        val outputFileSuccess = File(transductionParameters.outputFile.path).mkdir()
+        val outputFileSuccess = File(outputFile.path).mkdir()
         // If the output file cannot be created, an IOException should be caught
-        if (!outputFileSuccess and !transductionParameters.outputFile.exists()) {
+        if (!outputFileSuccess and !outputFile.exists()) {
             throw IOException("Unable to create folder for CSV files.")
         }
     }

--- a/src/main/kotlin/simplergc/services/colocalizer/output/XlsxColocalizationOutput.kt
+++ b/src/main/kotlin/simplergc/services/colocalizer/output/XlsxColocalizationOutput.kt
@@ -14,6 +14,7 @@ import simplergc.services.XlsxTableWriter
  * Outputs the analysis with the result of overlapping, transduced cells in XLSX format.
  */
 class XlsxColocalizationOutput(
+    private val outputFile: File,
     transductionParameters: Parameters.Transduction,
     private val workbook: XSSFWorkbook = XSSFWorkbook()
 ) :
@@ -22,7 +23,7 @@ class XlsxColocalizationOutput(
     override val tableWriter = XlsxTableWriter(workbook)
 
     fun writeWorkbook() {
-        val filename = FilenameUtils.removeExtension(transductionParameters.outputFile.path) ?: "Untitled"
+        val filename = FilenameUtils.removeExtension(outputFile.path) ?: "Untitled"
         val file = File("$filename.xlsx")
         val outputStream = file.outputStream()
 

--- a/src/main/kotlin/simplergc/services/counter/output/CsvCounterOutput.kt
+++ b/src/main/kotlin/simplergc/services/counter/output/CsvCounterOutput.kt
@@ -1,9 +1,10 @@
 package simplergc.services.counter.output
 
+import java.io.File
 import simplergc.services.CsvTableWriter
 import simplergc.services.Parameters
 
-class CsvCounterOutput(private val counterParameters: Parameters.Counter) : CounterOutput() {
+class CsvCounterOutput(private val outputFile: File, private val counterParameters: Parameters.Counter) : CounterOutput() {
 
     override val tableWriter = CsvTableWriter()
 
@@ -23,6 +24,6 @@ class CsvCounterOutput(private val counterParameters: Parameters.Counter) : Coun
                 gaussianBlurSigma = counterParameters.gaussianBlurSigma
                 ))
         }
-        tableWriter.produce(parametersAndResultsData, counterParameters.outputFile.absolutePath)
+        tableWriter.produce(parametersAndResultsData, outputFile.absolutePath)
     }
 }

--- a/src/main/kotlin/simplergc/services/counter/output/XlsxCounterOutput.kt
+++ b/src/main/kotlin/simplergc/services/counter/output/XlsxCounterOutput.kt
@@ -13,7 +13,7 @@ data class Citation(val article: String = "The article:", val citation: String =
     override fun toList() = listOf(StringField(article), StringField(citation))
 }
 
-class XlsxCounterOutput(private val counterParameters: Parameters.Counter) : CounterOutput() {
+class XlsxCounterOutput(private val outputFile: File, private val counterParameters: Parameters.Counter) : CounterOutput() {
 
     private val workbook = XSSFWorkbook()
 
@@ -59,7 +59,7 @@ class XlsxCounterOutput(private val counterParameters: Parameters.Counter) : Cou
         writeResults()
         writeParameters()
 
-        val filename = FilenameUtils.removeExtension(counterParameters.outputFile.path) ?: "Untitled"
+        val filename = FilenameUtils.removeExtension(outputFile.path) ?: "Untitled"
         val file = File("$filename.xlsx")
         val outputStream = file.outputStream()
 


### PR DESCRIPTION
Fixes the NullPointerException for using ImageJ output without a filename. 
This occurred because when constructing the Parameters object (before determining output type) there was a `!!` on `outputFile`. 

To fix it, I've decided to move the `outputFile` out from the `Parameters` object since it both fixes the issue, and you could argue that it's not the same type of 'parameter' as the others, as it is not to do with segmentation or analysis. 