### PR TITLE
Add check for number of channels in batch

### DIFF
--- a/src/main/kotlin/simplergc/commands/RGCTransduction.kt
+++ b/src/main/kotlin/simplergc/commands/RGCTransduction.kt
@@ -499,7 +499,7 @@ class RGCTransduction : Command, Previewable {
             }
 
             image.show()
-            drawCells(image, result.overlappingTwoChannelCells)
+            drawCells(image, result.overlappingOverlaidCells)
         }
     }
 

--- a/src/main/kotlin/simplergc/commands/batch/controllers/Files.kt
+++ b/src/main/kotlin/simplergc/commands/batch/controllers/Files.kt
@@ -60,5 +60,15 @@ fun openFiles(inputFiles: List<File>): List<ImagePlus> {
             )
         }
     }
+    checkImagesHaveSameNumChannels(inputImages)
     return inputImages
+}
+
+class ImagesHaveDifferentNumberOfChannelsException(message: String) : Exception(message)
+
+fun checkImagesHaveSameNumChannels(inputImages: List<ImagePlus>) {
+    // Check if number of channels in all images is the same as the first.
+    if (!inputImages.all { it.nChannels == inputImages.first().nChannels }) {
+        throw ImagesHaveDifferentNumberOfChannelsException("The images selected for processing have differing numbers of channels. Please ensure all images have the same number of channels and try again.")
+    }
 }

--- a/src/main/kotlin/simplergc/commands/batch/controllers/Files.kt
+++ b/src/main/kotlin/simplergc/commands/batch/controllers/Files.kt
@@ -64,11 +64,11 @@ fun openFiles(inputFiles: List<File>): List<ImagePlus> {
     return inputImages
 }
 
-class InconsistentChannelsException(message: String) : Exception(message)
+class InconsistentChannelsException() : Exception()
 
 fun checkImagesHaveSameNumChannels(inputImages: List<ImagePlus>) {
     // Check if number of channels in all images is the same as the first.
     if (!inputImages.all { it.nChannels == inputImages.first().nChannels }) {
-        throw InconsistentChannelsException("The images selected for processing have differing numbers of channels. Please ensure all images have the same number of channels and try again.")
+        throw InconsistentChannelsException()
     }
 }

--- a/src/main/kotlin/simplergc/commands/batch/controllers/Files.kt
+++ b/src/main/kotlin/simplergc/commands/batch/controllers/Files.kt
@@ -64,11 +64,11 @@ fun openFiles(inputFiles: List<File>): List<ImagePlus> {
     return inputImages
 }
 
-class ImagesHaveDifferentNumberOfChannelsException(message: String) : Exception(message)
+class InconsistentChannelsException(message: String) : Exception(message)
 
 fun checkImagesHaveSameNumChannels(inputImages: List<ImagePlus>) {
     // Check if number of channels in all images is the same as the first.
     if (!inputImages.all { it.nChannels == inputImages.first().nChannels }) {
-        throw ImagesHaveDifferentNumberOfChannelsException("The images selected for processing have differing numbers of channels. Please ensure all images have the same number of channels and try again.")
+        throw InconsistentChannelsException("The images selected for processing have differing numbers of channels. Please ensure all images have the same number of channels and try again.")
     }
 }

--- a/src/main/kotlin/simplergc/commands/batch/controllers/RGCController.kt
+++ b/src/main/kotlin/simplergc/commands/batch/controllers/RGCController.kt
@@ -34,8 +34,9 @@ abstract class RGCController(private val statusService: StatusService) {
 
         val inputImages: List<ImagePlus> = try {
             openFiles(orderedFiles)
-        } catch (ice: ImagesHaveDifferentNumberOfChannelsException) {
-            view.dialog("Error",
+        } catch (ice: InconsistentChannelsException) {
+            view.dialog(
+                "Error",
                 ice.message
                     ?: "The images selected for processing have differing numbers of channels. Please ensure all images have the same number of channels and try again."
             )

--- a/src/main/kotlin/simplergc/commands/batch/controllers/RGCController.kt
+++ b/src/main/kotlin/simplergc/commands/batch/controllers/RGCController.kt
@@ -37,8 +37,7 @@ abstract class RGCController(private val statusService: StatusService) {
         } catch (ice: InconsistentChannelsException) {
             view.dialog(
                 "Error",
-                ice.message
-                    ?: "The images selected for processing have differing numbers of channels. Please ensure all images have the same number of channels and try again."
+                "The images selected for processing have differing numbers of channels. Please ensure all images have the same number of channels and try again."
             )
             emptyList()
         }

--- a/src/main/kotlin/simplergc/commands/batch/controllers/RGCController.kt
+++ b/src/main/kotlin/simplergc/commands/batch/controllers/RGCController.kt
@@ -1,5 +1,6 @@
 package simplergc.commands.batch.controllers
 
+import ij.ImagePlus
 import java.awt.event.ActionListener
 import java.io.FileNotFoundException
 import java.io.IOException
@@ -31,8 +32,18 @@ abstract class RGCController(private val statusService: StatusService) {
         val files = getAllFiles(p.inputDirectory!!, p.shouldProcessFilesInNestedFolders)
         val orderedFiles = files.sortedWith(AlphanumFileComparator)
 
+        val inputImages: List<ImagePlus> = try {
+            openFiles(orderedFiles)
+        } catch (ice: ImagesHaveDifferentNumberOfChannelsException) {
+            view.dialog("Error",
+                ice.message
+                    ?: "The images selected for processing have differing numbers of channels. Please ensure all images have the same number of channels and try again."
+            )
+            emptyList()
+        }
+
         processor.process(
-            openFiles(orderedFiles),
+            inputImages,
             p.cellDiameterRange,
             p.thresholdRadius,
             p.gaussianBlurSigma,


### PR DESCRIPTION
closes #208
Before processing, check that each file has the same number of channels, otherwise, throw and exception and print an error dialog.