### PR TITLE
Add aggregate calculations to summary table for Batch Colocalisation

### DIFF
--- a/src/main/kotlin/simplergc/services/Table.kt
+++ b/src/main/kotlin/simplergc/services/Table.kt
@@ -212,7 +212,6 @@ class VerticallyMergedHeaderField(field: HeaderField, val rowSpan: Int) : Field<
 }
 
 enum class Aggregate(val abbreviation: String, val generateValue: (AggregateGenerator) -> Field<*>) {
-    Total("Total", AggregateGenerator::generateTotal),
     Mean("Mean", AggregateGenerator::generateMean),
     StandardDeviation("Std Dev", AggregateGenerator::generateStandardDeviation),
     StandardErrorOfMean("SEM", AggregateGenerator::generateStandardErrorOfMean),
@@ -220,7 +219,6 @@ enum class Aggregate(val abbreviation: String, val generateValue: (AggregateGene
 }
 
 abstract class AggregateGenerator {
-    abstract fun generateTotal(): Field<*>
     abstract fun generateMean(): Field<*>
     abstract fun generateStandardDeviation(): Field<*>
     abstract fun generateStandardErrorOfMean(): Field<*>
@@ -231,10 +229,6 @@ class XlsxAggregateGenerator(startRow: Int, column: Char, numCells: Int) : Aggre
 
     private val endCellRow = numCells + startRow - 1
     private val cellRange = "$column$startRow:$column$endCellRow"
-
-    override fun generateTotal(): Field<*> {
-        return DoubleFormulaField("SUM($cellRange)")
-    }
 
     override fun generateMean(): Field<*> {
         return DoubleFormulaField("AVERAGE($cellRange)")
@@ -259,10 +253,6 @@ class CsvAggregateGenerator(val values: List<Number>) : AggregateGenerator() {
         val squareOfMean = values.map { it.toDouble() }.average().pow(2)
         val meanOfSquares = values.map { it.toDouble().pow(2) }.average()
         return sqrt(meanOfSquares - squareOfMean)
-    }
-
-    override fun generateTotal(): Field<*> {
-        return DoubleField(values.sumByDouble { it.toDouble() })
     }
 
     override fun generateMean(): Field<*> {

--- a/src/main/kotlin/simplergc/services/Table.kt
+++ b/src/main/kotlin/simplergc/services/Table.kt
@@ -17,8 +17,6 @@ import org.scijava.table.DefaultColumn
 import org.scijava.table.DefaultGenericTable
 import org.scijava.ui.UIService
 
-private const val UTF_8_BOM = "\ufeff"
-
 /**
  * Table represents data in terms of rows and columns.
  */
@@ -172,8 +170,10 @@ class EmptyRow : BaseRow {
     override fun toList() = emptyList<Field<*>>()
 }
 
-// A MetricRow is a row for a given cell in a given file. The parameter metrics is nullable because not all columns are
-// of equal length so fields can be null.
+/**
+ * A MetricRow is a row for a given cell in a given file. The parameter metrics is nullable because not all columns are
+ * of equal length so fields can be null.
+ */
 data class MetricRow(val rowIdx: Int, val metrics: List<Field<*>>) : BaseRow {
     override fun toList(): List<Field<*>> {
         return listOf(IntField(rowIdx)) + metrics

--- a/src/main/kotlin/simplergc/services/Table.kt
+++ b/src/main/kotlin/simplergc/services/Table.kt
@@ -212,6 +212,7 @@ class VerticallyMergedHeaderField(field: HeaderField, val rowSpan: Int) : Field<
 }
 
 enum class Aggregate(val abbreviation: String, val generateValue: (AggregateGenerator) -> Field<*>) {
+    Total("Total", AggregateGenerator::generateTotal),
     Mean("Mean", AggregateGenerator::generateMean),
     StandardDeviation("Std Dev", AggregateGenerator::generateStandardDeviation),
     StandardErrorOfMean("SEM", AggregateGenerator::generateStandardErrorOfMean),
@@ -219,6 +220,7 @@ enum class Aggregate(val abbreviation: String, val generateValue: (AggregateGene
 }
 
 abstract class AggregateGenerator {
+    abstract fun generateTotal(): Field<*>
     abstract fun generateMean(): Field<*>
     abstract fun generateStandardDeviation(): Field<*>
     abstract fun generateStandardErrorOfMean(): Field<*>
@@ -229,6 +231,10 @@ class XlsxAggregateGenerator(startRow: Int, column: Char, numCells: Int) : Aggre
 
     private val endCellRow = numCells + startRow - 1
     private val cellRange = "$column$startRow:$column$endCellRow"
+
+    override fun generateTotal(): Field<*> {
+        return DoubleFormulaField("SUM($cellRange)")
+    }
 
     override fun generateMean(): Field<*> {
         return DoubleFormulaField("AVERAGE($cellRange)")
@@ -253,6 +259,10 @@ class CsvAggregateGenerator(val values: List<Number>) : AggregateGenerator() {
         val squareOfMean = values.map { it.toDouble() }.average().pow(2)
         val meanOfSquares = values.map { it.toDouble().pow(2) }.average()
         return sqrt(meanOfSquares - squareOfMean)
+    }
+
+    override fun generateTotal(): Field<*> {
+        return DoubleField(values.sumByDouble { it.toDouble() })
     }
 
     override fun generateMean(): Field<*> {

--- a/src/main/kotlin/simplergc/services/batch/output/BatchColocalizationOutput.kt
+++ b/src/main/kotlin/simplergc/services/batch/output/BatchColocalizationOutput.kt
@@ -111,7 +111,7 @@ abstract class BatchColocalizationOutput : Output {
             val rowFields = rowData.map { if (it != null) metric.toField(it) else StringField("") }
             t.addRow(MetricRow(rowIdx + 1, rowFields))
         }
-        colocalizationOutput.METRIC_AGGREGATES.forEach { t.addRow(generateAggregateRow(it, rawValues, 0)) }
+        Aggregate.values().forEach { t.addRow(generateAggregateRow(it, rawValues, 0)) }
         return t
     }
 }

--- a/src/main/kotlin/simplergc/services/batch/output/BatchColocalizationOutput.kt
+++ b/src/main/kotlin/simplergc/services/batch/output/BatchColocalizationOutput.kt
@@ -21,7 +21,13 @@ abstract class BatchColocalizationOutput : Output {
     private val fileNameAndResultsList = mutableListOf<Pair<String, TransductionResult>>()
 
     abstract val colocalizationOutput: ColocalizationOutput
-    abstract fun generateAggregateRow(aggregate: Aggregate, rawValues: List<List<Number>>, spaces: Int = 0): AggregateRow
+    abstract fun generateAggregateRow(
+        aggregate: Aggregate,
+        rawValues: List<List<Number>>,
+        spaces: Int = 0,
+        startRow: Int = 2
+    ): AggregateRow
+
     abstract fun writeDocumentation()
     abstract fun writeMetric(name: String, table: Table)
 

--- a/src/main/kotlin/simplergc/services/batch/output/BatchColocalizationOutput.kt
+++ b/src/main/kotlin/simplergc/services/batch/output/BatchColocalizationOutput.kt
@@ -32,7 +32,8 @@ abstract class BatchColocalizationOutput : Output {
 
     fun writeSheets() {
         writeDocumentation()
-        colocalizationOutput.writeSummary()
+
+        colocalizationOutput.writeSummaryWithAggregates()
 
         for (metricTable in computeMetricTables()) {
             writeMetric(metricTable.first, metricTable.second)

--- a/src/main/kotlin/simplergc/services/batch/output/BatchColocalizationOutput.kt
+++ b/src/main/kotlin/simplergc/services/batch/output/BatchColocalizationOutput.kt
@@ -111,8 +111,7 @@ abstract class BatchColocalizationOutput : Output {
             val rowFields = rowData.map { if (it != null) metric.toField(it) else StringField("") }
             t.addRow(MetricRow(rowIdx + 1, rowFields))
         }
-
-        Aggregate.values().forEach { t.addRow(generateAggregateRow(it, rawValues, 0)) }
+        colocalizationOutput.METRIC_AGGREGATES.forEach { t.addRow(generateAggregateRow(it, rawValues, 0)) }
         return t
     }
 }

--- a/src/main/kotlin/simplergc/services/batch/output/BatchCsvColocalizationOutput.kt
+++ b/src/main/kotlin/simplergc/services/batch/output/BatchCsvColocalizationOutput.kt
@@ -29,9 +29,10 @@ class BatchCsvColocalizationOutput(outputFile: File, transductionParameters: Par
     override fun generateAggregateRow(
         aggregate: Aggregate,
         rawValues: List<List<Number>>,
-        spaces: Int
+        spaces: Int,
+        startRow: Int
     ): AggregateRow {
-        return colocalizationOutput.generateAggregateRow(aggregate, rawValues, spaces)
+        return colocalizationOutput.generateAggregateRow(aggregate, rawValues, spaces, startRow)
     }
 
     override fun output() {

--- a/src/main/kotlin/simplergc/services/batch/output/BatchXlsxColocalizationOutput.kt
+++ b/src/main/kotlin/simplergc/services/batch/output/BatchXlsxColocalizationOutput.kt
@@ -33,9 +33,10 @@ class BatchXlsxColocalizationOutput(outputFile: File, transductionParameters: Pa
     override fun generateAggregateRow(
         aggregate: Aggregate,
         rawValues: List<List<Number>>,
-        spaces: Int
+        spaces: Int,
+        startRow: Int
     ): AggregateRow {
-        return colocalizationOutput.generateAggregateRow(aggregate, rawValues, spaces)
+        return colocalizationOutput.generateAggregateRow(aggregate, rawValues, spaces, startRow)
     }
 
     override fun output() {

--- a/src/main/kotlin/simplergc/services/batch/output/BatchXlsxColocalizationOutput.kt
+++ b/src/main/kotlin/simplergc/services/batch/output/BatchXlsxColocalizationOutput.kt
@@ -26,7 +26,7 @@ class BatchXlsxColocalizationOutput(outputFile: File, transductionParameters: Pa
     private val workbook = XSSFWorkbook()
 
     override val colocalizationOutput =
-        XlsxColocalizationOutput(outputFile, transductionParameters, workbook, cellStartRow = 2)
+        XlsxColocalizationOutput(outputFile, transductionParameters, workbook)
 
     override val tableWriter: TableWriter = XlsxTableWriter(workbook)
 

--- a/src/main/kotlin/simplergc/services/colocalizer/output/ColocalizationOutput.kt
+++ b/src/main/kotlin/simplergc/services/colocalizer/output/ColocalizationOutput.kt
@@ -132,10 +132,6 @@ abstract class ColocalizationOutput(val transductionParameters: Parameters.Trans
 
     val transducedChannel = transductionParameters.transducedChannel
 
-    val SUMMARY_AGGREGATES = Aggregate.values()
-    val METRIC_AGGREGATES =
-        listOf(Aggregate.Mean, Aggregate.StandardDeviation, Aggregate.StandardErrorOfMean, Aggregate.Count)
-
     companion object {
         const val PLUGIN_NAME = "RGC Transduction"
     }
@@ -160,6 +156,17 @@ abstract class ColocalizationOutput(val transductionParameters: Parameters.Trans
         startRow: Int = 2
     ): AggregateRow
 
+    fun addTotalRow(t: Table, rawCellCounts: List<Int>, rawTransducedCellCounts: List<Int>): Table {
+        val totalRow = AggregateRow(
+            "Total",
+            listOf(IntField(rawCellCounts.sum()), IntField(rawTransducedCellCounts.sum())),
+            spaces = 0
+        )
+        t.addRow(totalRow)
+        return t
+    }
+
+    // NOTE: This may be a very inefficient function, but there is no easier way to loop over columns of data.
     fun getSummaryRawValues(): MutableList<List<Number>> {
         val rawValues = mutableListOf<List<Number>>()
         val rawCellCounts = mutableListOf<Int>()

--- a/src/main/kotlin/simplergc/services/colocalizer/output/ColocalizationOutput.kt
+++ b/src/main/kotlin/simplergc/services/colocalizer/output/ColocalizationOutput.kt
@@ -160,6 +160,40 @@ abstract class ColocalizationOutput(val transductionParameters: Parameters.Trans
         startRow: Int = 2
     ): AggregateRow
 
+    fun getSummaryRawValues(): MutableList<List<Number>> {
+        val rawValues = mutableListOf<List<Number>>()
+        val rawCellCounts = mutableListOf<Int>()
+        val rawTransducedCellCounts = mutableListOf<Int>()
+        val rawTransductionEfficiencies = mutableListOf<Number>()
+        val rawMorphAreas = mutableListOf<Number>()
+        val numChannels = channelNames().size
+        val rawChannelMeans = Array<MutableList<Number>>(numChannels) { mutableListOf() }
+        val rawChannelMedians = Array<MutableList<Number>>(numChannels) { mutableListOf() }
+        val rawChannelMins = Array<MutableList<Number>>(numChannels) { mutableListOf() }
+        val rawChannelMaxs = Array<MutableList<Number>>(numChannels) { mutableListOf() }
+        val rawChannelIntDens = Array<MutableList<Number>>(numChannels) { mutableListOf() }
+        for ((_, result) in fileNameAndResultsList) {
+            rawCellCounts.add(result.targetCellCount)
+            rawTransducedCellCounts.add(result.transducedCellCount)
+            rawTransductionEfficiencies.add(result.transductionEfficiency)
+            rawMorphAreas.add(result.channelResults[0].avgMorphologyArea)
+            for (i in 0 until numChannels) {
+                rawChannelMeans[i].add(result.channelResults[i].meanFluorescenceIntensity)
+                rawChannelMedians[i].add(result.channelResults[i].medianFluorescenceIntensity)
+                rawChannelMins[i].add(result.channelResults[i].minFluorescenceIntensity)
+                rawChannelMaxs[i].add(result.channelResults[i].maxFluorescenceIntensity)
+                rawChannelIntDens[i].add(result.channelResults[i].rawIntDen)
+            }
+        }
+        rawValues.addAll(listOf(rawCellCounts, rawTransducedCellCounts, rawTransductionEfficiencies, rawMorphAreas))
+        rawValues.addAll(rawChannelMeans)
+        rawValues.addAll(rawChannelMedians)
+        rawValues.addAll(rawChannelMins)
+        rawValues.addAll(rawChannelMaxs)
+        rawValues.addAll(rawChannelIntDens)
+        return rawValues
+    }
+
     fun channelNames(): List<String> {
         if (fileNameAndResultsList.size == 0) {
             return emptyList()

--- a/src/main/kotlin/simplergc/services/colocalizer/output/ColocalizationOutput.kt
+++ b/src/main/kotlin/simplergc/services/colocalizer/output/ColocalizationOutput.kt
@@ -140,6 +140,8 @@ abstract class ColocalizationOutput(val transductionParameters: Parameters.Trans
         fileNameAndResultsList.add(Pair(file, transductionResult))
     }
 
+    abstract fun getSummaryTable(): Table
+    abstract fun writeSummaryWithAggregates()
     abstract fun writeSummary()
     abstract fun writeAnalysis()
     abstract fun writeParameters()

--- a/src/main/kotlin/simplergc/services/colocalizer/output/ColocalizationOutput.kt
+++ b/src/main/kotlin/simplergc/services/colocalizer/output/ColocalizationOutput.kt
@@ -132,6 +132,10 @@ abstract class ColocalizationOutput(val transductionParameters: Parameters.Trans
 
     val transducedChannel = transductionParameters.transducedChannel
 
+    val SUMMARY_AGGREGATES = Aggregate.values()
+    val METRIC_AGGREGATES =
+        listOf(Aggregate.Mean, Aggregate.StandardDeviation, Aggregate.StandardErrorOfMean, Aggregate.Count)
+
     companion object {
         const val PLUGIN_NAME = "RGC Transduction"
     }
@@ -146,10 +150,14 @@ abstract class ColocalizationOutput(val transductionParameters: Parameters.Trans
     abstract fun writeAnalysis()
     abstract fun writeParameters()
     abstract fun writeDocumentation()
+
+    // spaces is used for csv aggregate generator (to avoid formatting issues.)
+    // startRow is only used by xlsx aggregate generator
     abstract fun generateAggregateRow(
         aggregate: Aggregate,
         rawValues: List<List<Number>>,
-        spaces: Int
+        spaces: Int,
+        startRow: Int = 2
     ): AggregateRow
 
     fun channelNames(): List<String> {

--- a/src/main/kotlin/simplergc/services/colocalizer/output/ColocalizationOutput.kt
+++ b/src/main/kotlin/simplergc/services/colocalizer/output/ColocalizationOutput.kt
@@ -147,8 +147,10 @@ abstract class ColocalizationOutput(val transductionParameters: Parameters.Trans
     abstract fun writeParameters()
     abstract fun writeDocumentation()
 
-    // spaces is used for csv aggregate generator (to avoid formatting issues.)
-    // startRow is only used by xlsx aggregate generator
+    /**
+     * [spaces] is used by the CSV aggregate generator to avoid formatting issues.
+     * [startRow] is only used by the XLSX aggregate generator.
+     */
     abstract fun generateAggregateRow(
         aggregate: Aggregate,
         rawValues: List<List<Number>>,
@@ -166,38 +168,43 @@ abstract class ColocalizationOutput(val transductionParameters: Parameters.Trans
         return t
     }
 
-    // NOTE: This may be a very inefficient function, but there is no easier way to loop over columns of data.
     fun getSummaryRawValues(): MutableList<List<Number>> {
         val rawValues = mutableListOf<List<Number>>()
+
         val rawCellCounts = mutableListOf<Int>()
         val rawTransducedCellCounts = mutableListOf<Int>()
         val rawTransductionEfficiencies = mutableListOf<Number>()
         val rawMorphAreas = mutableListOf<Number>()
+
         val numChannels = channelNames().size
-        val rawChannelMeans = Array<MutableList<Number>>(numChannels) { mutableListOf() }
-        val rawChannelMedians = Array<MutableList<Number>>(numChannels) { mutableListOf() }
-        val rawChannelMins = Array<MutableList<Number>>(numChannels) { mutableListOf() }
-        val rawChannelMaxs = Array<MutableList<Number>>(numChannels) { mutableListOf() }
-        val rawChannelIntDens = Array<MutableList<Number>>(numChannels) { mutableListOf() }
+        val rawChannelMeans = Array(numChannels) { mutableListOf<Number>() }
+        val rawChannelMedians = Array(numChannels) { mutableListOf<Number>() }
+        val rawChannelMins = Array(numChannels) { mutableListOf<Number>() }
+        val rawChannelMaxs = Array(numChannels) { mutableListOf<Number>() }
+        val rawChannelIntDens = Array(numChannels) { mutableListOf<Number>() }
+
         for ((_, result) in fileNameAndResultsList) {
             rawCellCounts.add(result.targetCellCount)
             rawTransducedCellCounts.add(result.transducedCellCount)
             rawTransductionEfficiencies.add(result.transductionEfficiency)
             rawMorphAreas.add(result.channelResults[0].avgMorphologyArea)
             for (i in 0 until numChannels) {
-                rawChannelMeans[i].add(result.channelResults[i].meanFluorescenceIntensity)
-                rawChannelMedians[i].add(result.channelResults[i].medianFluorescenceIntensity)
-                rawChannelMins[i].add(result.channelResults[i].minFluorescenceIntensity)
-                rawChannelMaxs[i].add(result.channelResults[i].maxFluorescenceIntensity)
-                rawChannelIntDens[i].add(result.channelResults[i].rawIntDen)
+                val channelResult = result.channelResults[i]
+                rawChannelMeans[i].add(channelResult.meanFluorescenceIntensity)
+                rawChannelMedians[i].add(channelResult.medianFluorescenceIntensity)
+                rawChannelMins[i].add(channelResult.minFluorescenceIntensity)
+                rawChannelMaxs[i].add(channelResult.maxFluorescenceIntensity)
+                rawChannelIntDens[i].add(channelResult.rawIntDen)
             }
         }
+
         rawValues.addAll(listOf(rawCellCounts, rawTransducedCellCounts, rawTransductionEfficiencies, rawMorphAreas))
         rawValues.addAll(rawChannelMeans)
         rawValues.addAll(rawChannelMedians)
         rawValues.addAll(rawChannelMins)
         rawValues.addAll(rawChannelMaxs)
         rawValues.addAll(rawChannelIntDens)
+
         return rawValues
     }
 

--- a/src/main/kotlin/simplergc/services/colocalizer/output/CsvColocalizationOutput.kt
+++ b/src/main/kotlin/simplergc/services/colocalizer/output/CsvColocalizationOutput.kt
@@ -169,10 +169,12 @@ class CsvColocalizationOutput(
         }
     }
 
+    // startRow is unused
     override fun generateAggregateRow(
         aggregate: Aggregate,
         rawValues: List<List<Number>>,
-        spaces: Int
+        spaces: Int,
+        startRow: Int
     ): AggregateRow {
         return AggregateRow(aggregate.abbreviation, rawValues.map { values ->
             aggregate.generateValue(CsvAggregateGenerator(values))

--- a/src/main/kotlin/simplergc/services/colocalizer/output/CsvColocalizationOutput.kt
+++ b/src/main/kotlin/simplergc/services/colocalizer/output/CsvColocalizationOutput.kt
@@ -52,10 +52,19 @@ class CsvColocalizationOutput(
     override fun writeSummaryWithAggregates() {
         val t = getSummaryTable()
         val rawValues = getSummaryRawValues()
-        addTotalRow(t, rawCellCounts = rawValues[0] as List<Int>, rawTransducedCellCounts = rawValues[1] as List<Int>)
+
+        // rawValues[0] and rawValues[1] contain cell counts, and are guaranteed to contain integers.
+        @Suppress("UNCHECKED_CAST")
+        val rawCellCounts = rawValues[0] as List<Int>
+        @Suppress("UNCHECKED_CAST")
+        val rawTransducedCellCounts = rawValues[1] as List<Int>
+
+        addTotalRow(t, rawCellCounts = rawCellCounts, rawTransducedCellCounts = rawTransducedCellCounts)
+
         Aggregate.values().forEach {
             t.addRow(generateAggregateRow(it, rawValues, spaces = 0))
         }
+
         tableWriter.produce(t, "${outputPath}Summary.csv")
     }
 
@@ -120,7 +129,6 @@ class CsvColocalizationOutput(
 
                 Aggregate.values().forEach {
                     val rawValues = mutableListOf<List<Number>>()
-                    // TODO: Do we need to check  here if the channel index is transduction index.
                     Metric.values().forEach { metric ->
                         rawValues.add(result.channelResults[idx].cellAnalyses.map { cell ->
                             metric.compute(cell)
@@ -133,16 +141,20 @@ class CsvColocalizationOutput(
         }
     }
 
-    // startRow is unused
+    /**
+     * [startRow] is unused for the CSV output.
+     */
     override fun generateAggregateRow(
         aggregate: Aggregate,
         rawValues: List<List<Number>>,
         spaces: Int,
         startRow: Int
     ): AggregateRow {
-        return AggregateRow(aggregate.abbreviation, rawValues.map { values ->
+        val aggregates = rawValues.map { values ->
             aggregate.generateValue(CsvAggregateGenerator(values))
-        }, spaces)
+        }
+
+        return AggregateRow(aggregate.abbreviation, aggregates, spaces)
     }
 
     override fun writeParameters() {

--- a/src/main/kotlin/simplergc/services/colocalizer/output/CsvColocalizationOutput.kt
+++ b/src/main/kotlin/simplergc/services/colocalizer/output/CsvColocalizationOutput.kt
@@ -8,7 +8,6 @@ import simplergc.services.CsvAggregateGenerator
 import simplergc.services.CsvTableWriter
 import simplergc.services.FieldRow
 import simplergc.services.HeaderField
-import simplergc.services.IntField
 import simplergc.services.Metric
 import simplergc.services.Parameters
 import simplergc.services.Table

--- a/src/main/kotlin/simplergc/services/colocalizer/output/CsvColocalizationOutput.kt
+++ b/src/main/kotlin/simplergc/services/colocalizer/output/CsvColocalizationOutput.kt
@@ -53,14 +53,8 @@ class CsvColocalizationOutput(
     override fun writeSummaryWithAggregates() {
         val t = getSummaryTable()
         val rawValues = getSummaryRawValues()
-        // TODO: Create aggregate for total.
-        // val totalRow = AggregateRow(
-        //     "Total",
-        //     listOf(IntField(rawCellCounts.sum()), IntField(rawTransducedCellCounts.sum())),
-        //     spaces = 0
-        // )
-        // t.addRow(totalRow)
-        SUMMARY_AGGREGATES.forEach {
+        addTotalRow(t, rawCellCounts = rawValues[0] as List<Int>, rawTransducedCellCounts = rawValues[1] as List<Int>)
+        Aggregate.values().forEach {
             t.addRow(generateAggregateRow(it, rawValues, spaces = 0))
         }
         tableWriter.produce(t, "${outputPath}Summary.csv")
@@ -125,7 +119,7 @@ class CsvColocalizationOutput(
                     )
                 }
 
-                METRIC_AGGREGATES.forEach {
+                Aggregate.values().forEach {
                     val rawValues = mutableListOf<List<Number>>()
                     // TODO: Do we need to check  here if the channel index is transduction index.
                     Metric.values().forEach { metric ->

--- a/src/main/kotlin/simplergc/services/colocalizer/output/CsvColocalizationOutput.kt
+++ b/src/main/kotlin/simplergc/services/colocalizer/output/CsvColocalizationOutput.kt
@@ -89,7 +89,7 @@ class CsvColocalizationOutput(
         rawValues.addAll(rawChannelMins)
         rawValues.addAll(rawChannelMaxs)
         rawValues.addAll(rawChannelIntDens)
-        Aggregate.values().forEach {
+        SUMMARY_AGGREGATES.forEach {
             t.addRow(generateAggregateRow(it, rawValues, spaces = 0))
         }
         tableWriter.produce(t, "${outputPath}Summary.csv")
@@ -153,7 +153,8 @@ class CsvColocalizationOutput(
                         )
                     )
                 }
-                Aggregate.values().forEach {
+
+                METRIC_AGGREGATES.forEach {
                     val rawValues = mutableListOf<List<Number>>()
                     // TODO: Do we need to check  here if the channel index is transduction index.
                     Metric.values().forEach { metric ->

--- a/src/main/kotlin/simplergc/services/colocalizer/output/CsvColocalizationOutput.kt
+++ b/src/main/kotlin/simplergc/services/colocalizer/output/CsvColocalizationOutput.kt
@@ -52,43 +52,14 @@ class CsvColocalizationOutput(
 
     override fun writeSummaryWithAggregates() {
         val t = getSummaryTable()
-        val rawCellCounts = mutableListOf<Int>()
-        val rawTransducedCellCounts = mutableListOf<Int>()
-        val rawTransductionEfficiencies = mutableListOf<Number>()
-        val rawMorphAreas = mutableListOf<Number>()
-        val numChannels = channelNames().size
-        val rawChannelMeans = Array<MutableList<Number>>(numChannels) { mutableListOf() }
-        val rawChannelMedians = Array<MutableList<Number>>(numChannels) { mutableListOf() }
-        val rawChannelMins = Array<MutableList<Number>>(numChannels) { mutableListOf() }
-        val rawChannelMaxs = Array<MutableList<Number>>(numChannels) { mutableListOf() }
-        val rawChannelIntDens = Array<MutableList<Number>>(numChannels) { mutableListOf() }
-        for ((_, result) in fileNameAndResultsList) {
-            rawCellCounts.add(result.targetCellCount)
-            rawTransducedCellCounts.add(result.transducedCellCount)
-            rawTransductionEfficiencies.add(result.transductionEfficiency)
-            rawMorphAreas.add(result.channelResults[0].avgMorphologyArea)
-            for (i in 0 until numChannels) {
-                rawChannelMeans[i].add(result.channelResults[i].meanFluorescenceIntensity)
-                rawChannelMedians[i].add(result.channelResults[i].medianFluorescenceIntensity)
-                rawChannelMins[i].add(result.channelResults[i].minFluorescenceIntensity)
-                rawChannelMaxs[i].add(result.channelResults[i].maxFluorescenceIntensity)
-                rawChannelIntDens[i].add(result.channelResults[i].rawIntDen)
-            }
-        }
-        val rawValues = mutableListOf<List<Number>>(rawCellCounts, rawTransducedCellCounts)
+        val rawValues = getSummaryRawValues()
         // TODO: Create aggregate for total.
-        val totalRow = AggregateRow(
-            "Total",
-            listOf(IntField(rawCellCounts.sum()), IntField(rawTransducedCellCounts.sum())),
-            spaces = 0
-        )
-        t.addRow(totalRow)
-        rawValues.addAll(listOf(rawTransductionEfficiencies, rawMorphAreas))
-        rawValues.addAll(rawChannelMeans)
-        rawValues.addAll(rawChannelMedians)
-        rawValues.addAll(rawChannelMins)
-        rawValues.addAll(rawChannelMaxs)
-        rawValues.addAll(rawChannelIntDens)
+        // val totalRow = AggregateRow(
+        //     "Total",
+        //     listOf(IntField(rawCellCounts.sum()), IntField(rawTransducedCellCounts.sum())),
+        //     spaces = 0
+        // )
+        // t.addRow(totalRow)
         SUMMARY_AGGREGATES.forEach {
             t.addRow(generateAggregateRow(it, rawValues, spaces = 0))
         }

--- a/src/main/kotlin/simplergc/services/colocalizer/output/ImageJTableColocalizationOutput.kt
+++ b/src/main/kotlin/simplergc/services/colocalizer/output/ImageJTableColocalizationOutput.kt
@@ -75,11 +75,11 @@ class ImageJTableColocalizationOutput(
     }
 
     override fun getSummaryTable(): Table {
-        TODO("No-op.")
+        throw NotImplementedError("Summary table not available for ImageJ output")
     }
 
     override fun writeSummaryWithAggregates() {
-        TODO("No-op.")
+        throw NotImplementedError("Summary table not available for ImageJ output")
     }
 
     override fun writeAnalysis() {
@@ -104,11 +104,11 @@ class ImageJTableColocalizationOutput(
     }
 
     override fun writeParameters() {
-        TODO("No-op.")
+        throw NotImplementedError("Parameters not available for ImageJ output")
     }
 
     override fun writeDocumentation() {
-        TODO("No-op.")
+        throw NotImplementedError("Documentation not available for ImageJ output")
     }
 
     override fun generateAggregateRow(
@@ -117,7 +117,7 @@ class ImageJTableColocalizationOutput(
         spaces: Int,
         startRow: Int
     ): AggregateRow {
-        TODO("No-op.")
+        throw NotImplementedError("Aggregate not available for ImageJ output")
     }
 
     override fun output() {

--- a/src/main/kotlin/simplergc/services/colocalizer/output/ImageJTableColocalizationOutput.kt
+++ b/src/main/kotlin/simplergc/services/colocalizer/output/ImageJTableColocalizationOutput.kt
@@ -74,6 +74,14 @@ class ImageJTableColocalizationOutput(
                 count = (result.channelResults[transducedChannel - 1].cellAnalyses.sumByDouble { it.mean } / result.channelResults[transducedChannel - 1].cellAnalyses.size).toInt()))
     }
 
+    override fun getSummaryTable(): Table {
+        TODO("Not yet implemented")
+    }
+
+    override fun writeSummaryWithAggregates() {
+        TODO("Not yet implemented")
+    }
+
     override fun writeAnalysis() {
         channelNames().forEachIndexed { idx, name ->
             table.addRow(Row(label = "--- Cell Analysis, $name ---"))

--- a/src/main/kotlin/simplergc/services/colocalizer/output/ImageJTableColocalizationOutput.kt
+++ b/src/main/kotlin/simplergc/services/colocalizer/output/ImageJTableColocalizationOutput.kt
@@ -1,5 +1,6 @@
 package simplergc.services.colocalizer.output
 
+import kotlin.math.roundToInt
 import org.scijava.ui.UIService
 import simplergc.commands.RGCTransduction.TransductionResult
 import simplergc.services.Aggregate

--- a/src/main/kotlin/simplergc/services/colocalizer/output/ImageJTableColocalizationOutput.kt
+++ b/src/main/kotlin/simplergc/services/colocalizer/output/ImageJTableColocalizationOutput.kt
@@ -1,6 +1,5 @@
 package simplergc.services.colocalizer.output
 
-import kotlin.math.roundToInt
 import org.scijava.ui.UIService
 import simplergc.commands.RGCTransduction.TransductionResult
 import simplergc.services.Aggregate
@@ -75,11 +74,11 @@ class ImageJTableColocalizationOutput(
     }
 
     override fun getSummaryTable(): Table {
-        TODO("Not yet implemented")
+        TODO("No-op.")
     }
 
     override fun writeSummaryWithAggregates() {
-        TODO("Not yet implemented")
+        TODO("No-op.")
     }
 
     override fun writeAnalysis() {
@@ -104,20 +103,20 @@ class ImageJTableColocalizationOutput(
     }
 
     override fun writeParameters() {
-        // no-op
+        TODO("No-op.")
     }
 
     override fun writeDocumentation() {
-        // no-op
+        TODO("No-op.")
     }
 
     override fun generateAggregateRow(
         aggregate: Aggregate,
         rawValues: List<List<Number>>,
-        spaces: Int
+        spaces: Int,
+        startRow: Int
     ): AggregateRow {
-        // no-op
-        return AggregateRow("", emptyList())
+        TODO("No-op.")
     }
 
     override fun output() {

--- a/src/main/kotlin/simplergc/services/colocalizer/output/XlsxColocalizationOutput.kt
+++ b/src/main/kotlin/simplergc/services/colocalizer/output/XlsxColocalizationOutput.kt
@@ -78,43 +78,15 @@ class XlsxColocalizationOutput(
 
     override fun writeSummaryWithAggregates() {
         val t: Table = getSummaryTable()
-        val rawCellCounts = mutableListOf<Int>()
-        val rawTransducedCellCounts = mutableListOf<Int>()
-        val rawTransductionEfficiencies = mutableListOf<Number>()
-        val rawMorphAreas = mutableListOf<Number>()
-        val numChannels = channelNames().size
-        val rawChannelMeans = Array<MutableList<Number>>(numChannels) { mutableListOf() }
-        val rawChannelMedians = Array<MutableList<Number>>(numChannels) { mutableListOf() }
-        val rawChannelMins = Array<MutableList<Number>>(numChannels) { mutableListOf() }
-        val rawChannelMaxs = Array<MutableList<Number>>(numChannels) { mutableListOf() }
-        val rawChannelIntDens = Array<MutableList<Number>>(numChannels) { mutableListOf() }
-        for ((_, result) in fileNameAndResultsList) {
-            rawCellCounts.add(result.targetCellCount)
-            rawTransducedCellCounts.add(result.transducedCellCount)
-            rawTransductionEfficiencies.add(result.transductionEfficiency)
-            rawMorphAreas.add(result.channelResults[0].avgMorphologyArea)
-            for (i in 0 until numChannels) {
-                rawChannelMeans[i].add(result.channelResults[i].meanFluorescenceIntensity)
-                rawChannelMedians[i].add(result.channelResults[i].medianFluorescenceIntensity)
-                rawChannelMins[i].add(result.channelResults[i].minFluorescenceIntensity)
-                rawChannelMaxs[i].add(result.channelResults[i].maxFluorescenceIntensity)
-                rawChannelIntDens[i].add(result.channelResults[i].rawIntDen)
-            }
-        }
-        val rawValues = mutableListOf<List<Number>>(rawCellCounts, rawTransducedCellCounts)
-        // TODO: Create aggregate for total.
-        val totalRow = AggregateRow(
-            "Total",
-            listOf(IntField(rawCellCounts.sum()), IntField(rawTransducedCellCounts.sum())),
-            spaces = 0
-        )
-        t.addRow(totalRow)
-        rawValues.addAll(listOf(rawTransductionEfficiencies, rawMorphAreas))
-        rawValues.addAll(rawChannelMeans)
-        rawValues.addAll(rawChannelMedians)
-        rawValues.addAll(rawChannelMins)
-        rawValues.addAll(rawChannelMaxs)
-        rawValues.addAll(rawChannelIntDens)
+        val rawValues = getSummaryRawValues()
+        // TODO: only use indices 0 and 1 of raw values for total
+        // val totalRow = AggregateRow(
+        //     "Total",
+        //     listOf(IntField(rawCellCounts.sum()), IntField(rawTransducedCellCounts.sum())),
+        //     spaces = 0
+        // )
+        // t.addRow(totalRow)
+        // TODO: Think about total
         SUMMARY_AGGREGATES.forEach {
             t.addRow(generateAggregateRow(it, rawValues, spaces = 0, startRow = 3))
         }

--- a/src/main/kotlin/simplergc/services/colocalizer/output/XlsxColocalizationOutput.kt
+++ b/src/main/kotlin/simplergc/services/colocalizer/output/XlsxColocalizationOutput.kt
@@ -64,12 +64,24 @@ class XlsxColocalizationOutput(
         rawValues.forEach { values ->
             rowValues.add(aggregate.generateValue(
                 XlsxAggregateGenerator(cellStartRow, column++, values.size)
-            ))
+            )
+            )
         }
         return AggregateRow(aggregate.abbreviation, rowValues, spaces)
     }
 
     override fun writeSummary() {
+        val t: Table = getSummaryTable()
+        tableWriter.produce(t, "Summary")
+    }
+
+    override fun writeSummaryWithAggregates() {
+        val t: Table = getSummaryTable()
+        // TODO: Get raw values and add aggregates here.
+        tableWriter.produce(t, "Summary")
+    }
+
+    override fun getSummaryTable(): Table {
         val channelNames = channelNames()
         val headers = mutableListOf(
             "File Name",
@@ -100,9 +112,10 @@ class XlsxColocalizationOutput(
 
         // Add summary data.
         for ((fileName, result) in fileNameAndResultsList) {
+            // TODO: figure out what raw values are and return as pair with table.
             t.addRow(SummaryRow(fileName = fileName, summary = result))
         }
-        tableWriter.produce(t, "Summary")
+        return t
     }
 
     override fun writeAnalysis() {
@@ -110,7 +123,8 @@ class XlsxColocalizationOutput(
         val channelNames = channelNames()
         val headers = listOf(
             "File Name",
-            "Transduced Cell").map { VerticallyMergedHeaderField(HeaderField(it), 2) }
+            "Transduced Cell"
+        ).map { VerticallyMergedHeaderField(HeaderField(it), 2) }
 
         val subHeaders: MutableList<Field<*>> = MutableList(headers.size) { StringField("") }
         val metricHeaders = mutableListOf<Field<*>>()

--- a/src/main/kotlin/simplergc/services/colocalizer/output/XlsxColocalizationOutput.kt
+++ b/src/main/kotlin/simplergc/services/colocalizer/output/XlsxColocalizationOutput.kt
@@ -62,9 +62,10 @@ class XlsxColocalizationOutput(
         var column = 'B' + spaces
         val rowValues = mutableListOf<Field<*>>()
         rawValues.forEach { values ->
-            rowValues.add(aggregate.generateValue(
-                XlsxAggregateGenerator(startRow, column++, values.size)
-            )
+            rowValues.add(
+                aggregate.generateValue(
+                    XlsxAggregateGenerator(startRow, column++, values.size)
+                )
             )
         }
         return AggregateRow(aggregate.abbreviation, rowValues, spaces)
@@ -76,12 +77,21 @@ class XlsxColocalizationOutput(
     }
 
     override fun writeSummaryWithAggregates() {
-        val t: Table = getSummaryTable()
+        val t = getSummaryTable()
         val rawValues = getSummaryRawValues()
-        addTotalRow(t, rawCellCounts = rawValues[0] as List<Int>, rawTransducedCellCounts = rawValues[1] as List<Int>)
+
+        // rawValues[0] and rawValues[1] contain cell counts, and are guaranteed to contain integers.
+        @Suppress("UNCHECKED_CAST")
+        val rawCellCounts = rawValues[0] as List<Int>
+        @Suppress("UNCHECKED_CAST")
+        val rawTransducedCellCounts = rawValues[1] as List<Int>
+
+        addTotalRow(t, rawCellCounts = rawCellCounts, rawTransducedCellCounts = rawTransducedCellCounts)
+
         Aggregate.values().forEach {
             t.addRow(generateAggregateRow(it, rawValues, spaces = 0, startRow = 3))
         }
+
         tableWriter.produce(t, "Summary")
     }
 
@@ -116,9 +126,9 @@ class XlsxColocalizationOutput(
 
         // Add summary data.
         for ((fileName, result) in fileNameAndResultsList) {
-            // TODO: figure out what raw values are and return as pair with table.
             t.addRow(SummaryRow(fileName = fileName, summary = result))
         }
+
         return t
     }
 
@@ -150,15 +160,15 @@ class XlsxColocalizationOutput(
 
         for ((fileName, result) in fileNameAndResultsList) {
             val cellAnalyses = result.channelResults[transducedChannel - 1].cellAnalyses
-            for (i in cellAnalyses.indices) {
+            for (cell in cellAnalyses.indices) {
                 val channelAnalyses = mutableListOf<CellColocalizationService.CellAnalysis>()
-                for (idx in channelNames.indices) {
-                    channelAnalyses.add(result.channelResults[idx].cellAnalyses[i])
+                for (channel in channelNames.indices) {
+                    channelAnalyses.add(result.channelResults[channel].cellAnalyses[cell])
                 }
                 t.addRow(
                     MultiChannelTransductionAnalysisRow(
                         fileName,
-                        i + 1,
+                        cell + 1,
                         channelAnalyses,
                         transducedChannel - 1
                     )
@@ -173,8 +183,8 @@ class XlsxColocalizationOutput(
                             metric.compute(cell)
                         })
                     } else {
-                        for (idx in channelNames.indices) {
-                            rawValues.add(result.channelResults[idx].cellAnalyses.map { cell ->
+                        for (channel in channelNames.indices) {
+                            rawValues.add(result.channelResults[channel].cellAnalyses.map { cell ->
                                 metric.compute(cell)
                             })
                         }

--- a/src/main/kotlin/simplergc/services/colocalizer/output/XlsxColocalizationOutput.kt
+++ b/src/main/kotlin/simplergc/services/colocalizer/output/XlsxColocalizationOutput.kt
@@ -10,7 +10,6 @@ import simplergc.services.Field
 import simplergc.services.FieldRow
 import simplergc.services.HeaderField
 import simplergc.services.HorizontallyMergedHeaderField
-import simplergc.services.IntField
 import simplergc.services.Metric
 import simplergc.services.Metric.ChannelSelection.TRANSDUCTION_ONLY
 import simplergc.services.Parameters
@@ -79,15 +78,8 @@ class XlsxColocalizationOutput(
     override fun writeSummaryWithAggregates() {
         val t: Table = getSummaryTable()
         val rawValues = getSummaryRawValues()
-        // TODO: only use indices 0 and 1 of raw values for total
-        // val totalRow = AggregateRow(
-        //     "Total",
-        //     listOf(IntField(rawCellCounts.sum()), IntField(rawTransducedCellCounts.sum())),
-        //     spaces = 0
-        // )
-        // t.addRow(totalRow)
-        // TODO: Think about total
-        SUMMARY_AGGREGATES.forEach {
+        addTotalRow(t, rawCellCounts = rawValues[0] as List<Int>, rawTransducedCellCounts = rawValues[1] as List<Int>)
+        Aggregate.values().forEach {
             t.addRow(generateAggregateRow(it, rawValues, spaces = 0, startRow = 3))
         }
         tableWriter.produce(t, "Summary")
@@ -173,7 +165,7 @@ class XlsxColocalizationOutput(
                 )
             }
 
-            for (aggregate in METRIC_AGGREGATES) {
+            for (aggregate in Aggregate.values()) {
                 val rawValues = mutableListOf<List<Number>>()
                 for (metric in Metric.values()) {
                     if (metric.channels == TRANSDUCTION_ONLY) {


### PR DESCRIPTION
Aims to add the highlighted aggregate calculations for RGC Batch XLSX and CSV output to the summary table:

Batch Colocalisation
![image](https://user-images.githubusercontent.com/33670466/115055069-e78f8800-9ed8-11eb-968b-48c906aeb3d1.png)
