### PR TITLE
Use Double for mean and set all double fields to display at 3 decimal places

### DIFF
--- a/src/main/kotlin/simplergc/commands/RGCTransduction.kt
+++ b/src/main/kotlin/simplergc/commands/RGCTransduction.kt
@@ -221,7 +221,7 @@ class RGCTransduction : Command, Previewable {
 
     data class ChannelResult(val name: String, val cellAnalyses: List<CellAnalysis>) {
         var avgMorphologyArea = 0
-        var meanFluorescenceIntensity = 0
+        var meanFluorescenceIntensity = 0.0
         var medianFluorescenceIntensity = 0
         var minFluorescenceIntensity = 0
         var maxFluorescenceIntensity = 0
@@ -229,7 +229,7 @@ class RGCTransduction : Command, Previewable {
         init {
             if (cellAnalyses.isNotEmpty()) {
                 avgMorphologyArea = (cellAnalyses.sumBy { it.area } / cellAnalyses.size)
-                meanFluorescenceIntensity = (cellAnalyses.sumBy { it.mean } / cellAnalyses.size)
+                meanFluorescenceIntensity = (cellAnalyses.sumByDouble { it.mean } / cellAnalyses.size)
                 medianFluorescenceIntensity = (cellAnalyses.sumBy { it.median } / cellAnalyses.size)
                 minFluorescenceIntensity = (cellAnalyses.sumBy { it.min } / cellAnalyses.size)
                 maxFluorescenceIntensity = (cellAnalyses.sumBy { it.max } / cellAnalyses.size)

--- a/src/main/kotlin/simplergc/services/CellColocalizationService.kt
+++ b/src/main/kotlin/simplergc/services/CellColocalizationService.kt
@@ -12,7 +12,7 @@ class CellColocalizationService : AbstractService(), ImageJService {
 
     data class CellAnalysis(
         val area: Int,
-        val mean: Int,
+        val mean: Double,
         val median: Int,
         val min: Int,
         val max: Int,
@@ -38,7 +38,7 @@ class CellColocalizationService : AbstractService(), ImageJService {
             val median = sortedPixelintensities.let { (it[it.size / 2] + it[(it.size - 1) / 2]) / 2 }
             val min = sortedPixelintensities.first()
             val max = sortedPixelintensities.last()
-            CellAnalysis(area, sum / area, median, min, max, rawIntDen = sum)
+            CellAnalysis(area, sum.toDouble() / area, median, min, max, rawIntDen = sum)
         }
     }
 

--- a/src/main/kotlin/simplergc/services/Metric.kt
+++ b/src/main/kotlin/simplergc/services/Metric.kt
@@ -16,8 +16,9 @@ enum class Metric(
     val value: String,
     val full: String,
     val description: String,
-    val compute: (CellColocalizationService.CellAnalysis) -> Int,
+    val compute: (CellColocalizationService.CellAnalysis) -> Number,
     val channels: ChannelSelection,
+    val toField: (Number) -> Field<*>,
     summaryName: String? = null
 ) {
     Area(
@@ -26,6 +27,7 @@ enum class Metric(
         "Average morphology area (pixel$UTF_8_SUP2) for each transduced cell",
         CellColocalizationService.CellAnalysis::area,
         ChannelSelection.TRANSDUCTION_ONLY,
+        { IntField(it.toInt()) },
         "Average Morphology Area (pixel$UTF_8_SUP2)"
     ),
     Mean(
@@ -33,35 +35,40 @@ enum class Metric(
         "Mean Fluorescence Intensity (a.u.)",
         "Mean fluorescence intensity for each transduced cell",
         CellColocalizationService.CellAnalysis::mean,
-        ChannelSelection.ALL_CHANNELS
+        ChannelSelection.ALL_CHANNELS,
+        { DoubleField(it.toDouble()) }
     ),
     Median(
         "Median Int",
         "Median Fluorescence Intensity (a.u.)",
         "Median fluorescence intensity for each transduced cell",
         CellColocalizationService.CellAnalysis::median,
-        ChannelSelection.ALL_CHANNELS
+        ChannelSelection.ALL_CHANNELS,
+        { IntField(it.toInt()) }
     ),
     Min(
         "Min Int",
         "Min Fluorescence Intensity (a.u.)",
         "Min fluorescence intensity for each transduced cell",
         CellColocalizationService.CellAnalysis::min,
-        ChannelSelection.ALL_CHANNELS
+        ChannelSelection.ALL_CHANNELS,
+        { IntField(it.toInt()) }
     ),
     Max(
         "Max Int",
         "Max Fluorescence Intensity (a.u.)",
         "Max fluorescence intensity for each transduced cell",
         CellColocalizationService.CellAnalysis::max,
-        ChannelSelection.ALL_CHANNELS
+        ChannelSelection.ALL_CHANNELS,
+        { IntField(it.toInt()) }
     ),
     IntDen(
         "Raw IntDen",
         "Raw Integrated Density",
         "Raw Integrated Density for each transduced cell",
         CellColocalizationService.CellAnalysis::rawIntDen,
-        ChannelSelection.ALL_CHANNELS
+        ChannelSelection.ALL_CHANNELS,
+        { IntField(it.toInt()) }
     );
 
     val summaryHeader = summaryName ?: full

--- a/src/main/kotlin/simplergc/services/batch/output/BatchCsvColocalizationOutput.kt
+++ b/src/main/kotlin/simplergc/services/batch/output/BatchCsvColocalizationOutput.kt
@@ -28,7 +28,7 @@ class BatchCsvColocalizationOutput(outputFile: File, transductionParameters: Par
 
     override fun generateAggregateRow(
         aggregate: Aggregate,
-        rawValues: List<List<Int>>,
+        rawValues: List<List<Number>>,
         spaces: Int
     ): AggregateRow {
         return colocalizationOutput.generateAggregateRow(aggregate, rawValues, spaces)

--- a/src/main/kotlin/simplergc/services/batch/output/BatchXlsxColocalizationOutput.kt
+++ b/src/main/kotlin/simplergc/services/batch/output/BatchXlsxColocalizationOutput.kt
@@ -32,7 +32,7 @@ class BatchXlsxColocalizationOutput(outputFile: File, transductionParameters: Pa
 
     override fun generateAggregateRow(
         aggregate: Aggregate,
-        rawValues: List<List<Int>>,
+        rawValues: List<List<Number>>,
         spaces: Int
     ): AggregateRow {
         return colocalizationOutput.generateAggregateRow(aggregate, rawValues, spaces)

--- a/src/main/kotlin/simplergc/services/colocalizer/output/ColocalizationOutput.kt
+++ b/src/main/kotlin/simplergc/services/colocalizer/output/ColocalizationOutput.kt
@@ -64,7 +64,7 @@ data class SummaryRow(
         )
         // Add each channel's metric values grouped by metric
         summary.channelResults.forEach { channelResult ->
-            fields.add(IntField(channelResult.meanFluorescenceIntensity))
+            fields.add(DoubleField(channelResult.meanFluorescenceIntensity))
         }
         summary.channelResults.forEach { channelResult ->
             fields.add(IntField(channelResult.medianFluorescenceIntensity))
@@ -93,7 +93,7 @@ data class SingleChannelTransductionAnalysisRow(
             IntField(transducedCell)
         )
         for (metric in Metric.values()) {
-            fields.add(IntField(metric.compute(cellAnalysis)))
+            fields.add(IntField(metric.compute(cellAnalysis).toInt()))
         }
         return fields
     }
@@ -112,10 +112,10 @@ data class MultiChannelTransductionAnalysisRow(
         )
         for (metric in Metric.values()) {
             if (metric.channels == TRANSDUCTION_ONLY) {
-                fields.add(IntField(metric.compute(cellAnalyses[transductionChannel])))
+                fields.add(IntField(metric.compute(cellAnalyses[transductionChannel]).toInt()))
             } else {
                 for (cellAnalysis in cellAnalyses) {
-                    fields.add(IntField(metric.compute(cellAnalysis)))
+                    fields.add(IntField(metric.compute(cellAnalysis).toInt()))
                 }
             }
         }
@@ -146,7 +146,7 @@ abstract class ColocalizationOutput(val transductionParameters: Parameters.Trans
     abstract fun writeDocumentation()
     abstract fun generateAggregateRow(
         aggregate: Aggregate,
-        rawValues: List<List<Int>>,
+        rawValues: List<List<Number>>,
         spaces: Int
     ): AggregateRow
 

--- a/src/main/kotlin/simplergc/services/colocalizer/output/CsvColocalizationOutput.kt
+++ b/src/main/kotlin/simplergc/services/colocalizer/output/CsvColocalizationOutput.kt
@@ -101,7 +101,7 @@ class CsvColocalizationOutput(
                     )
                 }
                 Aggregate.values().forEach {
-                    val rawValues = mutableListOf<List<Int>>()
+                    val rawValues = mutableListOf<List<Number>>()
                     Metric.values().forEach { metric ->
                         rawValues.add(result.channelResults[idx].cellAnalyses.map { cell ->
                             metric.compute(cell)
@@ -116,7 +116,7 @@ class CsvColocalizationOutput(
 
     override fun generateAggregateRow(
         aggregate: Aggregate,
-        rawValues: List<List<Int>>,
+        rawValues: List<List<Number>>,
         spaces: Int
     ): AggregateRow {
         return AggregateRow(aggregate.abbreviation, rawValues.map { values ->

--- a/src/main/kotlin/simplergc/services/colocalizer/output/ImageJTableColocalizationOutput.kt
+++ b/src/main/kotlin/simplergc/services/colocalizer/output/ImageJTableColocalizationOutput.kt
@@ -6,6 +6,7 @@ import simplergc.commands.RGCTransduction.TransductionResult
 import simplergc.services.Aggregate
 import simplergc.services.AggregateRow
 import simplergc.services.BaseRow
+import simplergc.services.DoubleField
 import simplergc.services.FieldRow
 import simplergc.services.ImageJTableWriter
 import simplergc.services.IntField
@@ -40,8 +41,8 @@ class ImageJTableColocalizationOutput(
         val count: Int = 0,
         val area: Int = 0,
         val median: Int = 0,
-        val mean: Int = 0,
-        val integratedDensity: Int = 0,
+        val mean: Double = 0.0,
+        val integratedDensity: Double = 0.0,
         val rawIntegratedDensity: Int = 0
     ) : BaseRow {
         override fun toList() = listOf(
@@ -49,8 +50,8 @@ class ImageJTableColocalizationOutput(
             IntField(count),
             IntField(area),
             IntField(median),
-            IntField(mean),
-            IntField(integratedDensity),
+            DoubleField(mean),
+            DoubleField(integratedDensity),
             IntField(rawIntegratedDensity)
         )
     }
@@ -70,7 +71,7 @@ class ImageJTableColocalizationOutput(
         table.addRow(
             Row(
                 label = "Mean intensity of colocalized cells",
-                count = result.channelResults[transducedChannel - 1].cellAnalyses.sumBy { it.mean } / result.channelResults[transducedChannel - 1].cellAnalyses.size))
+                count = (result.channelResults[transducedChannel - 1].cellAnalyses.sumByDouble { it.mean } / result.channelResults[transducedChannel - 1].cellAnalyses.size).toInt()))
     }
 
     override fun writeAnalysis() {
@@ -104,7 +105,7 @@ class ImageJTableColocalizationOutput(
 
     override fun generateAggregateRow(
         aggregate: Aggregate,
-        rawValues: List<List<Int>>,
+        rawValues: List<List<Number>>,
         spaces: Int
     ): AggregateRow {
         // no-op

--- a/src/main/kotlin/simplergc/services/colocalizer/output/XlsxColocalizationOutput.kt
+++ b/src/main/kotlin/simplergc/services/colocalizer/output/XlsxColocalizationOutput.kt
@@ -56,7 +56,7 @@ class XlsxColocalizationOutput(
 
     override fun generateAggregateRow(
         aggregate: Aggregate,
-        rawValues: List<List<Int>>,
+        rawValues: List<List<Number>>,
         spaces: Int
     ): AggregateRow {
         var column = 'B' + spaces
@@ -148,7 +148,7 @@ class XlsxColocalizationOutput(
             }
 
             for (aggregate in Aggregate.values()) {
-                val rawValues = mutableListOf<List<Int>>()
+                val rawValues = mutableListOf<List<Number>>()
                 for (metric in Metric.values()) {
                     if (metric.channels == TRANSDUCTION_ONLY) {
                         rawValues.add(result.channelResults[transducedChannel - 1].cellAnalyses.map { cell ->

--- a/src/test/kotlin/simplergc/services/CellColocalizationServiceTest.kt
+++ b/src/test/kotlin/simplergc/services/CellColocalizationServiceTest.kt
@@ -7,10 +7,10 @@ class CellColocalizationServiceTest : StringSpec({
     "counts cells correctly" {
         val cellColocalizationService = CellColocalizationService()
         val analyses = arrayOf(
-            CellColocalizationService.CellAnalysis(5, 100, 100, 100, 500, 1000),
-            CellColocalizationService.CellAnalysis(20, 88, 88, 88, 1760, 3000),
-            CellColocalizationService.CellAnalysis(20, 10, 10, 10, 200, 1000),
-            CellColocalizationService.CellAnalysis(20, 15, 15, 15, 300, 1000)
+            CellColocalizationService.CellAnalysis(5, 100.0, 100, 100, 500, 1000),
+            CellColocalizationService.CellAnalysis(20, 88.0, 88, 88, 1760, 3000),
+            CellColocalizationService.CellAnalysis(20, 10.0, 10, 10, 200, 1000),
+            CellColocalizationService.CellAnalysis(20, 15.0, 15, 15, 300, 1000)
         )
 
         cellColocalizationService.countChannel(analyses, 30.0) shouldBe 2


### PR DESCRIPTION
Change how we represent mean in our analyses/metrics to use Double. This meant also changing Metrics to work with Numbers rather than Ints. Then changed the cell outputs to display at 3 d.p in Excel. 